### PR TITLE
Add runtime cookie management and proxy rotation helpers

### DIFF
--- a/HttpRequestMessageExtensions.cs
+++ b/HttpRequestMessageExtensions.cs
@@ -85,7 +85,7 @@ namespace Moljave.Http
 
             if (options == null)
             {
-                request.Options.Remove(MojaveOptionsKey);
+                request.Options.Remove(MojaveOptionsKey, out _);
                 return;
             }
 

--- a/MojaveCookieManager.cs
+++ b/MojaveCookieManager.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+
+namespace Moljave.Http
+{
+    public sealed class MojaveCookieManager
+    {
+        private readonly object _syncRoot = new();
+        private CookieContainer _container;
+
+        public MojaveCookieManager()
+            : this(new CookieContainer())
+        {
+        }
+
+        public MojaveCookieManager(CookieContainer container)
+        {
+            _container = container ?? new CookieContainer();
+        }
+
+        public CookieCollection GetCookies(Uri uri)
+        {
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            lock (_syncRoot)
+            {
+                var collection = _container.GetCookies(uri);
+                var cloned = new CookieCollection();
+                foreach (Cookie cookie in collection)
+                {
+                    cloned.Add(CloneCookie(cookie));
+                }
+
+                return cloned;
+            }
+        }
+
+        public string GetCookieHeader(Uri uri)
+        {
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            lock (_syncRoot)
+            {
+                return _container.GetCookieHeader(uri);
+            }
+        }
+
+        public void SetCookie(Uri uri, Cookie cookie)
+        {
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (cookie == null)
+            {
+                throw new ArgumentNullException(nameof(cookie));
+            }
+
+            lock (_syncRoot)
+            {
+                _container.Add(uri, cookie);
+            }
+        }
+
+        public void SetCookie(string domain, string name, string value, string path = "/", DateTime? expires = null, bool? secure = null, bool? httpOnly = null)
+        {
+            if (string.IsNullOrWhiteSpace(domain))
+            {
+                throw new ArgumentNullException(nameof(domain));
+            }
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            var cookie = new Cookie(name, value ?? string.Empty, string.IsNullOrEmpty(path) ? "/" : path, domain);
+
+            if (expires.HasValue)
+            {
+                cookie.Expires = expires.Value;
+            }
+
+            if (secure.HasValue)
+            {
+                cookie.Secure = secure.Value;
+            }
+
+            if (httpOnly.HasValue)
+            {
+                cookie.HttpOnly = httpOnly.Value;
+            }
+
+            lock (_syncRoot)
+            {
+                _container.Add(cookie);
+            }
+        }
+
+        public void RemoveCookie(string domain, string name, string path = "/")
+        {
+            if (string.IsNullOrWhiteSpace(domain))
+            {
+                throw new ArgumentNullException(nameof(domain));
+            }
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            var cookie = new Cookie(name, string.Empty, string.IsNullOrEmpty(path) ? "/" : path, domain)
+            {
+                Expires = DateTime.UtcNow.AddYears(-1)
+            };
+
+            lock (_syncRoot)
+            {
+                _container.Add(cookie);
+            }
+        }
+
+        public void ClearAll()
+        {
+            lock (_syncRoot)
+            {
+                _container = new CookieContainer();
+            }
+        }
+
+        public void ClearDomain(string domain)
+        {
+            if (string.IsNullOrWhiteSpace(domain))
+            {
+                throw new ArgumentNullException(nameof(domain));
+            }
+
+            lock (_syncRoot)
+            {
+                var updated = new CookieContainer();
+                foreach (var cookie in EnumerateCookiesInternal())
+                {
+                    if (!IsDomainMatch(cookie.Domain, domain))
+                    {
+                        updated.Add(CloneCookie(cookie));
+                    }
+                }
+
+                _container = updated;
+            }
+        }
+
+        public void ClearDomain(Uri uri)
+        {
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            ClearDomain(uri.Host);
+        }
+
+        public void ReplaceWith(CookieContainer container)
+        {
+            lock (_syncRoot)
+            {
+                _container = container ?? new CookieContainer();
+            }
+        }
+
+        internal CookieContainer GetInternalContainer()
+        {
+            lock (_syncRoot)
+            {
+                return _container;
+            }
+        }
+
+        internal void UpdateFromSetCookieHeaders(Uri uri, IEnumerable<string> setCookieHeaders)
+        {
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (setCookieHeaders == null)
+            {
+                return;
+            }
+
+            lock (_syncRoot)
+            {
+                foreach (var header in setCookieHeaders.Where(h => !string.IsNullOrWhiteSpace(h)))
+                {
+                    _container.SetCookies(uri, header);
+                }
+            }
+        }
+
+        private IEnumerable<Cookie> EnumerateCookiesInternal()
+        {
+            var domainTableField = typeof(CookieContainer).GetField("m_domainTable", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (domainTableField == null)
+            {
+                yield break;
+            }
+
+            var domainTable = domainTableField.GetValue(_container) as Hashtable;
+            if (domainTable == null)
+            {
+                yield break;
+            }
+
+            foreach (DictionaryEntry entry in domainTable)
+            {
+                var pathList = entry.Value;
+                var pathListType = pathList.GetType();
+                var listField = pathListType.GetField("m_list", BindingFlags.NonPublic | BindingFlags.Instance);
+                if (listField?.GetValue(pathList) is not SortedList paths)
+                {
+                    continue;
+                }
+
+                foreach (DictionaryEntry pathEntry in paths)
+                {
+                    if (pathEntry.Value is CookieCollection cookies)
+                    {
+                        foreach (Cookie cookie in cookies)
+                        {
+                            yield return cookie;
+                        }
+                    }
+                }
+            }
+        }
+
+        private static Cookie CloneCookie(Cookie cookie)
+        {
+            return new Cookie(cookie?.Name ?? string.Empty, cookie?.Value ?? string.Empty, cookie?.Path ?? "/", cookie?.Domain ?? string.Empty)
+            {
+                Expires = cookie?.Expires ?? DateTime.MinValue,
+                HttpOnly = cookie?.HttpOnly ?? false,
+                Secure = cookie?.Secure ?? false
+            };
+        }
+
+        private static bool IsDomainMatch(string cookieDomain, string targetDomain)
+        {
+            if (string.IsNullOrWhiteSpace(cookieDomain) || string.IsNullOrWhiteSpace(targetDomain))
+            {
+                return false;
+            }
+
+            var normalizedCookie = NormalizeDomain(cookieDomain);
+            var normalizedTarget = NormalizeDomain(targetDomain);
+
+            if (string.Equals(normalizedCookie, normalizedTarget, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return normalizedCookie.EndsWith("." + normalizedTarget, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string NormalizeDomain(string domain)
+        {
+            if (string.IsNullOrWhiteSpace(domain))
+            {
+                return string.Empty;
+            }
+
+            return domain.Trim().TrimStart('.').ToLowerInvariant();
+        }
+    }
+}

--- a/MojaveHttpClientOptions.cs
+++ b/MojaveHttpClientOptions.cs
@@ -19,7 +19,19 @@ namespace Moljave.Http
         public Func<MojaveProxyOptions> ProxyResolver { get; set; }
             = () => MojaveProxyOptions.NoProxy;
 
-        public CookieContainer CookieContainer { get; set; } = new();
+        private MojaveCookieManager _cookieManager = new();
+
+        public MojaveCookieManager CookieManager
+        {
+            get => _cookieManager;
+            set => _cookieManager = value ?? new MojaveCookieManager();
+        }
+
+        public CookieContainer CookieContainer
+        {
+            get => _cookieManager?.GetInternalContainer();
+            set => (_cookieManager ??= new MojaveCookieManager()).ReplaceWith(value ?? new CookieContainer());
+        }
 
         public bool AllowAutoRedirect { get; set; } = true;
 
@@ -78,7 +90,7 @@ namespace Moljave.Http
         public TimeSpan? Timeout { get; set; }
         public bool? AllowAutoRedirect { get; set; }
         public int? MaxAutomaticRedirections { get; set; }
-        public CookieContainer CookieContainer { get; set; }
+        public MojaveCookieManager CookieManager { get; set; }
 
         internal MojaveRequestOptions Clone() => new()
         {
@@ -88,7 +100,7 @@ namespace Moljave.Http
             Timeout = Timeout,
             AllowAutoRedirect = AllowAutoRedirect,
             MaxAutomaticRedirections = MaxAutomaticRedirections,
-            CookieContainer = CookieContainer
+            CookieManager = CookieManager
         };
     }
 

--- a/MojaveHttpMessageHandler.cs
+++ b/MojaveHttpMessageHandler.cs
@@ -9,8 +9,6 @@ namespace Moljave.Http
     internal sealed class MojaveHttpMessageHandler : HttpMessageHandler
     {
         private readonly MojaveHttpClientOptions _options;
-        private readonly object _cookieLock = new();
-
         public MojaveHttpMessageHandler(MojaveHttpClientOptions options)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
@@ -36,7 +34,7 @@ namespace Moljave.Http
             var effectiveTimeout = requestOptions.Timeout ?? _options.DefaultTimeout;
             var allowRedirect = requestOptions.AllowAutoRedirect ?? _options.AllowAutoRedirect;
             var maxRedirects = requestOptions.MaxAutomaticRedirections ?? _options.MaxAutomaticRedirections;
-            var cookieContainer = requestOptions.CookieContainer ?? _options.CookieContainer;
+            var cookieManager = requestOptions.CookieManager ?? _options.CookieManager;
             var fingerprint = requestOptions.Fingerprint ?? _options.FingerprintProvider?.Invoke() ?? JA3Fingerprint.Default;
             var tlsSettings = requestOptions.TlsSettings ?? _options.TlsSettingsProvider?.Invoke() ?? MojaveTlsSettings.Default;
             var proxyOptions = requestOptions.Proxy ?? _options.ProxyResolver?.Invoke() ?? MojaveProxyOptions.NoProxy;
@@ -51,13 +49,9 @@ namespace Moljave.Http
                 request.Headers.TryAddWithoutValidation("Accept-Encoding", "gzip, deflate, br");
             }
 
-            if (cookieContainer != null)
+            if (cookieManager != null)
             {
-                string cookieHeader;
-                lock (_cookieLock)
-                {
-                    cookieHeader = cookieContainer.GetCookieHeader(uri);
-                }
+                var cookieHeader = cookieManager.GetCookieHeader(uri);
 
                 if (!string.IsNullOrEmpty(cookieHeader))
                 {
@@ -86,15 +80,9 @@ namespace Moljave.Http
 
             var response = HttpResponseParser.Parse(responseBytes);
 
-            if (cookieContainer != null && response.Headers.TryGetValues("Set-Cookie", out var setCookieHeaders))
+            if (cookieManager != null && response.Headers.TryGetValues("Set-Cookie", out var setCookieHeaders))
             {
-                lock (_cookieLock)
-                {
-                    foreach (var cookie in setCookieHeaders)
-                    {
-                        cookieContainer.SetCookies(uri, cookie);
-                    }
-                }
+                cookieManager.UpdateFromSetCookieHeaders(uri, setCookieHeaders);
             }
 
             if (allowRedirect && IsRedirect(response.StatusCode))

--- a/MoljaveHttpClient.cs
+++ b/MoljaveHttpClient.cs
@@ -10,26 +10,48 @@ namespace Moljave.Http
     {
         private readonly MojaveHttpClientOptions _options;
         private readonly HttpMessageInvoker _invoker;
+        private readonly MojaveCookieManager _cookieManager;
+        private readonly object _fingerprintLock = new();
+        private readonly object _proxyLock = new();
+        private Func<JA3Fingerprint> _fingerprintFactory;
+        private JA3Fingerprint _currentFingerprint;
         private bool _disposed;
 
-        public MojaveHttpClient(
-            JA3Fingerprint ja3Fingerprint = null,
-            CookieContainer cookieContainer = null,
-            WebProxy proxy = null)
-            : this(new MojaveHttpClientOptions
+        public MojaveHttpClient()
+            : this(new MojaveHttpClientOptions())
+        {
+        }
+
+        public MojaveHttpClient(CookieContainer cookieContainer, WebProxy proxy = null)
+            : this(options =>
             {
-                FingerprintProvider = () => ja3Fingerprint ?? JA3FingerprintFactory.GetFingerprint(BrowserJa3Profile.Chrome),
-                CookieContainer = cookieContainer ?? new CookieContainer(),
-                ProxyResolver = proxy != null
-                    ? () => MojaveProxyOptions.FromWebProxy(proxy)
-                    : () => MojaveProxyOptions.NoProxy
+                if (cookieContainer != null)
+                {
+                    options.CookieContainer = cookieContainer;
+                }
+
+                if (proxy != null)
+                {
+                    options.ProxyResolver = () => MojaveProxyOptions.FromWebProxy(proxy);
+                }
             })
+        {
+        }
+
+        public MojaveHttpClient(Action<MojaveHttpClientOptions> configure)
+            : this(BuildOptions(configure))
         {
         }
 
         public MojaveHttpClient(MojaveHttpClientOptions options)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
+            _cookieManager = _options.CookieManager ?? new MojaveCookieManager();
+            _options.CookieManager = _cookieManager;
+
+            InitializeFingerprint(_options.FingerprintProvider);
+            _options.FingerprintProvider = ResolveFingerprint;
+
             _invoker = new HttpMessageInvoker(_options.BuildHandlerPipeline(), disposeHandler: true);
         }
 
@@ -53,9 +75,72 @@ namespace Moljave.Http
 
         public CookieContainer CookieContainer
         {
-            get => _options.CookieContainer;
-            set => _options.CookieContainer = value ?? new CookieContainer();
+            get => _cookieManager.GetInternalContainer();
+            set => _cookieManager.ReplaceWith(value ?? new CookieContainer());
         }
+
+        public MojaveCookieManager CookieManager => _cookieManager;
+
+        public void RotateFingerprint()
+        {
+            lock (_fingerprintLock)
+            {
+                _currentFingerprint = (_fingerprintFactory ?? DefaultFingerprintFactory)();
+            }
+        }
+
+        public void UseFingerprintProvider(Func<JA3Fingerprint> provider, bool rotateImmediately = true)
+        {
+            if (provider == null)
+            {
+                throw new ArgumentNullException(nameof(provider));
+            }
+
+            lock (_fingerprintLock)
+            {
+                _fingerprintFactory = provider;
+                _currentFingerprint = rotateImmediately ? provider() : null;
+            }
+        }
+
+        public void UseProxy(MojaveProxyOptions proxyOptions)
+        {
+            if (proxyOptions == null)
+            {
+                throw new ArgumentNullException(nameof(proxyOptions));
+            }
+
+            lock (_proxyLock)
+            {
+                _options.ProxyResolver = () => proxyOptions;
+            }
+        }
+
+        public void UseProxy(WebProxy proxy)
+        {
+            lock (_proxyLock)
+            {
+                _options.ProxyResolver = proxy != null
+                    ? () => MojaveProxyOptions.FromWebProxy(proxy)
+                    : () => MojaveProxyOptions.NoProxy;
+            }
+        }
+
+        public void UseProxyResolver(Func<MojaveProxyOptions> resolver)
+        {
+            lock (_proxyLock)
+            {
+                _options.ProxyResolver = resolver ?? (() => MojaveProxyOptions.NoProxy);
+            }
+        }
+
+        public void ClearProxy() => UseProxy((WebProxy)null);
+
+        public void ClearAllCookies() => _cookieManager.ClearAll();
+
+        public void ClearCookiesForDomain(string domain) => _cookieManager.ClearDomain(domain);
+
+        public void ClearCookiesForDomain(Uri uri) => _cookieManager.ClearDomain(uri);
 
         public void Dispose()
         {
@@ -93,5 +178,33 @@ namespace Moljave.Http
 
             return _invoker.SendAsync(request, cancellationToken);
         }
+
+        private void InitializeFingerprint(Func<JA3Fingerprint> fingerprintProvider)
+        {
+            lock (_fingerprintLock)
+            {
+                _fingerprintFactory = fingerprintProvider ?? DefaultFingerprintFactory;
+                _currentFingerprint = _fingerprintFactory();
+            }
+        }
+
+        private JA3Fingerprint ResolveFingerprint()
+        {
+            lock (_fingerprintLock)
+            {
+                _currentFingerprint ??= (_fingerprintFactory ?? DefaultFingerprintFactory)();
+                return _currentFingerprint;
+            }
+        }
+
+        private static MojaveHttpClientOptions BuildOptions(Action<MojaveHttpClientOptions> configure)
+        {
+            var options = new MojaveHttpClientOptions();
+            configure?.Invoke(options);
+            return options;
+        }
+
+        private static JA3Fingerprint DefaultFingerprintFactory()
+            => JA3FingerprintFactory.GetFingerprint(BrowserJa3Profile.Chrome);
     }
 }

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
 
 ## 🚀 Features
 
-- **Custom TLS (JA3) Fingerprinting** — simulate Chrome or your own fingerprint, or rotate per request
+- **Custom TLS (JA3) Fingerprinting** — automatically generated per-client, rotate with a single call, or supply your own profile
 - **SOCKS4/SOCKS4a/SOCKS5 & HTTP/HTTPS Proxy support** — including authentication and remote DNS
 - **Automatic redirects** — configurable at runtime or per request
-- **CookieContainer support** — browser-like cookie handling with thread-safety in mind
+- **Advanced cookie management** — tweak, clear or replace cookies at runtime with thread-safety in mind
 - **DelegatingHandler pipeline** — plug in your own handlers like with regular `HttpClient`
 - **Per-request overrides** — change proxy/TLS/fingerprint/timeout for individual calls
 - **Custom headers** — send and control order like a browser
@@ -46,18 +46,14 @@ class Program
 {
     static async Task Main()
     {
-        // Select browser JA3 fingerprint profile
-        var ja3 = JA3FingerprintFactory.GetFingerprint(BrowserJa3Profile.Chrome);
-
-        // Optional: Use CookieContainer and/or Proxy
-        var cookies = new CookieContainer();
-        var proxy = new WebProxy("socks5://127.0.0.1:9050"); // Or use HTTP proxy
-
-        using var client = new MojaveHttpClient(ja3, cookies, proxy)
+        using var client = new MojaveHttpClient()
         {
             AllowAutoRedirect = true,
             DefaultTimeout = TimeSpan.FromSeconds(20)
         };
+
+        // Optionally plug in a proxy at runtime
+        client.UseProxy(new WebProxy("socks5://127.0.0.1:9050"));
 
         var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com/");
         request.AddHeaders(@"
@@ -80,8 +76,6 @@ class Program
 ```csharp
 var options = new MojaveHttpClientOptions
 {
-    FingerprintProvider = () => JA3FingerprintFactory.GetFingerprint(BrowserJa3Profile.Chrome),
-    CookieContainer = new CookieContainer(),
     DefaultTimeout = TimeSpan.FromSeconds(25),
     ProxyResolver = () => ProxyParser.TryParse(GetNextProxy(), out var proxy)
         ? proxy
@@ -92,6 +86,12 @@ var options = new MojaveHttpClientOptions
 options.DelegatingHandlerFactories.Add(() => new MyTelemetryHandler());
 
 using var client = new MojaveHttpClient(options);
+
+// rotate to a fresh JA3 fingerprint whenever you need
+client.RotateFingerprint();
+
+// set or mutate cookies at runtime
+client.CookieManager.SetCookie("example.com", "session", "12345");
 
 var request = new HttpRequestMessage(HttpMethod.Get, "https://api.example.com/data");
 request.ConfigureMojaveOptions(o =>
@@ -108,6 +108,35 @@ request.ConfigureMojaveOptions(o =>
 });
 
 var response = await client.SendAsync(request);
+```
+
+### 🍪 Cookie management cheatsheet
+
+```csharp
+// Update a cookie value on the fly
+client.CookieManager.SetCookie("example.com", "session", "new-value");
+
+// Remove a specific cookie
+client.CookieManager.RemoveCookie("example.com", "session");
+
+// Clear cookies for a single domain or every domain
+client.ClearCookiesForDomain("example.com");
+client.ClearAllCookies();
+```
+
+### 🧭 Hot proxy switching
+
+```csharp
+// Use a direct proxy instance
+client.UseProxy(new WebProxy("http://127.0.0.1:8888"));
+
+// Swap proxies on the fly
+client.UseProxyResolver(() => ProxyParser.TryParse(GetNextProxy(), out var proxy)
+    ? proxy
+    : MojaveProxyOptions.NoProxy);
+
+// Reset back to no proxy
+client.ClearProxy();
 ```
 ## 🧪 Custom JA3 Example
 


### PR DESCRIPTION
## Summary
- fix Mojave request option removal to use the proper HttpRequestOptions.Remove overload
- introduce MojaveCookieManager and wire it through the client/handler for live cookie inspection, mutation, and clearing
- simplify MojaveHttpClient defaults with automatic JA3 provisioning plus new proxy/fingerprint helpers, and document the streamlined workflow

## Testing
- not run (no solution or project file provided)


------
https://chatgpt.com/codex/tasks/task_e_68ee522d81808332940a8517c9b357d0