### PR TITLE
Add HTTP/2 support and improve redirect handling

### DIFF
--- a/HttpContentUtilities.cs
+++ b/HttpContentUtilities.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http;
+
+namespace Moljave.Http
+{
+    internal static class HttpContentUtilities
+    {
+        public static ByteArrayContent CreateContent(
+            byte[] body,
+            IList<KeyValuePair<string, string>> headers,
+            out bool wasDecompressed)
+        {
+            var payload = DecodeBody(body, headers, out wasDecompressed);
+            var content = new ByteArrayContent(payload);
+
+            if (headers != null)
+            {
+                foreach (var header in headers)
+                {
+                    if (header.Key.Equals("Content-Length", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    if (wasDecompressed && header.Key.Equals("Content-Encoding", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+            }
+
+            content.Headers.ContentLength = payload.LongLength;
+            return content;
+        }
+
+        private static byte[] DecodeBody(byte[] body, IList<KeyValuePair<string, string>> headers, out bool wasDecompressed)
+        {
+            wasDecompressed = false;
+
+            if (body == null || body.Length == 0 || headers == null || headers.Count == 0)
+            {
+                return body ?? Array.Empty<byte>();
+            }
+
+            var encodingHeader = headers.FirstOrDefault(h =>
+                h.Key.Equals("Content-Encoding", StringComparison.OrdinalIgnoreCase));
+
+            if (string.IsNullOrEmpty(encodingHeader.Key))
+            {
+                return body;
+            }
+
+            try
+            {
+                if (encodingHeader.Value.Contains("gzip", StringComparison.OrdinalIgnoreCase))
+                {
+                    wasDecompressed = true;
+                    return Decompress(body, stream => new GZipStream(stream, CompressionMode.Decompress));
+                }
+
+                if (encodingHeader.Value.Contains("deflate", StringComparison.OrdinalIgnoreCase))
+                {
+                    wasDecompressed = true;
+                    return Decompress(body, stream => new DeflateStream(stream, CompressionMode.Decompress));
+                }
+
+                if (encodingHeader.Value.Contains("br", StringComparison.OrdinalIgnoreCase))
+                {
+                    wasDecompressed = true;
+                    return Decompress(body, stream => new BrotliStream(stream, CompressionMode.Decompress));
+                }
+            }
+            catch
+            {
+                wasDecompressed = false;
+            }
+
+            return body;
+        }
+
+        private static byte[] Decompress(byte[] body, Func<Stream, Stream> factory)
+        {
+            using var input = new MemoryStream(body);
+            using var decompressor = factory(input);
+            using var output = new MemoryStream();
+            decompressor.CopyTo(output);
+            return output.ToArray();
+        }
+    }
+}
+

--- a/HttpRequestMessageExtensions.cs
+++ b/HttpRequestMessageExtensions.cs
@@ -85,7 +85,7 @@ namespace Moljave.Http
 
             if (options == null)
             {
-                request.Options.Remove(MojaveOptionsKey, out _);
+                request.Options.Remove(MojaveOptionsKey.Key, out _);
                 return;
             }
 

--- a/HttpRequestStringifier.cs
+++ b/HttpRequestStringifier.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -105,7 +106,12 @@ namespace Moljave.Http
                 newMethod = HttpMethod.Get;
             }
 
-            var newRequest = new HttpRequestMessage(newMethod, newUri);
+            var newRequest = new HttpRequestMessage(newMethod, newUri)
+            {
+                Version = oldRequest.Version
+            };
+
+            CopyVersionPolicy(oldRequest, newRequest);
 
             foreach (var header in oldRequest.Headers)
             {
@@ -123,6 +129,18 @@ namespace Moljave.Http
             }
 
             return newRequest;
+        }
+
+        internal static void CopyVersionPolicy(HttpRequestMessage source, HttpRequestMessage destination)
+        {
+            var versionPolicyProperty = typeof(HttpRequestMessage).GetProperty("VersionPolicy");
+            if (versionPolicyProperty == null)
+            {
+                return;
+            }
+
+            var value = versionPolicyProperty.GetValue(source);
+            versionPolicyProperty.SetValue(destination, value);
         }
     }
 }

--- a/HttpResponseParser.cs
+++ b/HttpResponseParser.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -80,26 +79,7 @@ namespace Moljave.Http
                 }
             }
 
-            var decodedBody = DecodeBody(bodyBytes, contentHeaders, out bool wasDecompressed);
-            var content = new ByteArrayContent(decodedBody);
-
-            foreach (var header in contentHeaders)
-            {
-                if (header.Key.Equals("Content-Length", StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
-                if (wasDecompressed && header.Key.Equals("Content-Encoding", StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
-                content.Headers.TryAddWithoutValidation(header.Key, header.Value);
-            }
-
-            content.Headers.ContentLength = decodedBody.LongLength;
-            response.Content = content;
+            response.Content = HttpContentUtilities.CreateContent(bodyBytes, contentHeaders, out _);
             return response;
         }
 
@@ -115,57 +95,6 @@ namespace Moljave.Http
             }
 
             return -1;
-        }
-
-        private static byte[] DecodeBody(byte[] body, List<KeyValuePair<string, string>> headers, out bool wasDecompressed)
-        {
-            wasDecompressed = false;
-            if (body == null || body.Length == 0 || headers == null)
-            {
-                return body ?? Array.Empty<byte>();
-            }
-
-            var encodingHeader = headers.FirstOrDefault(h => h.Key.Equals("Content-Encoding", StringComparison.OrdinalIgnoreCase));
-            if (string.IsNullOrEmpty(encodingHeader.Key))
-            {
-                return body;
-            }
-
-            try
-            {
-                if (encodingHeader.Value.Contains("gzip", StringComparison.OrdinalIgnoreCase))
-                {
-                    wasDecompressed = true;
-                    return Decompress(body, stream => new GZipStream(stream, CompressionMode.Decompress));
-                }
-
-                if (encodingHeader.Value.Contains("deflate", StringComparison.OrdinalIgnoreCase))
-                {
-                    wasDecompressed = true;
-                    return Decompress(body, stream => new DeflateStream(stream, CompressionMode.Decompress));
-                }
-
-                if (encodingHeader.Value.Contains("br", StringComparison.OrdinalIgnoreCase))
-                {
-                    wasDecompressed = true;
-                    return Decompress(body, stream => new BrotliStream(stream, CompressionMode.Decompress));
-                }
-            }
-            catch
-            {
-                wasDecompressed = false;
-            }
-
-            return body;
-        }
-
-        private static byte[] Decompress(byte[] body, Func<Stream, Stream> factory)
-        {
-            using var input = new MemoryStream(body);
-            using var decompressor = factory(input);
-            using var output = new MemoryStream();
-            decompressor.CopyTo(output);
-            return output.ToArray();
         }
     }
 }

--- a/MojaveHttpMessageHandler.cs
+++ b/MojaveHttpMessageHandler.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -26,40 +30,119 @@ namespace Moljave.Http
                 throw new ArgumentNullException(nameof(request));
             }
 
-            var uri = request.RequestUri ?? throw new InvalidOperationException("RequestUri is required");
-            var useTls = string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
+            var currentRequest = request;
+            var currentRedirectCount = redirectCount;
 
-            var requestOptions = request.GetMojaveOptions()?.Clone() ?? new MojaveRequestOptions();
-
-            var effectiveTimeout = requestOptions.Timeout ?? _options.DefaultTimeout;
-            var allowRedirect = requestOptions.AllowAutoRedirect ?? _options.AllowAutoRedirect;
-            var maxRedirects = requestOptions.MaxAutomaticRedirections ?? _options.MaxAutomaticRedirections;
-            var cookieManager = requestOptions.CookieManager ?? _options.CookieManager;
-            var fingerprint = requestOptions.Fingerprint ?? _options.FingerprintProvider?.Invoke() ?? JA3Fingerprint.Default;
-            var tlsSettings = requestOptions.TlsSettings ?? _options.TlsSettingsProvider?.Invoke() ?? MojaveTlsSettings.Default;
-            var proxyOptions = requestOptions.Proxy ?? _options.ProxyResolver?.Invoke() ?? MojaveProxyOptions.NoProxy;
-
-            if (request.Content != null)
+            while (true)
             {
-                request.Content = await request.Content.BufferAsync().ConfigureAwait(false);
-            }
+                var uri = currentRequest.RequestUri ?? throw new InvalidOperationException("RequestUri is required");
+                var useTls = string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
 
-            if (!request.Headers.Contains("Accept-Encoding"))
-            {
-                request.Headers.TryAddWithoutValidation("Accept-Encoding", "gzip, deflate, br");
-            }
+                var requestOptions = currentRequest.GetMojaveOptions();
+                var effectiveTimeout = requestOptions?.Timeout ?? _options.DefaultTimeout;
+                var maxRedirects = requestOptions?.MaxAutomaticRedirections ?? _options.MaxAutomaticRedirections;
+                var cookieManager = requestOptions?.CookieManager ?? _options.CookieManager;
+                var fingerprint = requestOptions?.Fingerprint ?? _options.FingerprintProvider?.Invoke() ?? JA3Fingerprint.Default;
+                var tlsSettings = requestOptions?.TlsSettings ?? _options.TlsSettingsProvider?.Invoke() ?? MojaveTlsSettings.Default;
+                var proxyOptions = requestOptions?.Proxy ?? _options.ProxyResolver?.Invoke() ?? MojaveProxyOptions.NoProxy;
 
-            if (cookieManager != null)
-            {
-                var cookieHeader = cookieManager.GetCookieHeader(uri);
-
-                if (!string.IsNullOrEmpty(cookieHeader))
+                if (currentRequest.Content != null)
                 {
-                    request.Headers.Remove("Cookie");
-                    request.Headers.TryAddWithoutValidation("Cookie", cookieHeader);
+                    currentRequest.Content = await currentRequest.Content.BufferAsync().ConfigureAwait(false);
                 }
+
+                if (!currentRequest.Headers.Contains("Accept-Encoding"))
+                {
+                    currentRequest.Headers.TryAddWithoutValidation("Accept-Encoding", "gzip, deflate, br");
+                }
+
+                if (cookieManager != null)
+                {
+                    var cookieHeader = cookieManager.GetCookieHeader(uri);
+                    if (!string.IsNullOrEmpty(cookieHeader))
+                    {
+                        currentRequest.Headers.Remove("Cookie");
+                        currentRequest.Headers.TryAddWithoutValidation("Cookie", cookieHeader);
+                    }
+                }
+
+                HttpResponseMessage response = ShouldUseHttp2(currentRequest)
+                    ? await SendHttp2Async(currentRequest, uri, effectiveTimeout, fingerprint, tlsSettings, proxyOptions, cancellationToken).ConfigureAwait(false)
+                    : await SendHttp11Async(currentRequest, uri, useTls, effectiveTimeout, fingerprint, tlsSettings, proxyOptions, cancellationToken).ConfigureAwait(false);
+
+                if (cookieManager != null && response.Headers.TryGetValues("Set-Cookie", out var setCookieHeaders))
+                {
+                    cookieManager.UpdateFromSetCookieHeaders(uri, setCookieHeaders);
+                }
+
+                var redirectOptions = currentRequest.GetMojaveOptions();
+                var allowRedirect = (redirectOptions?.AllowAutoRedirect ?? requestOptions?.AllowAutoRedirect ?? _options.AllowAutoRedirect);
+
+                if (!allowRedirect || !IsRedirect(response.StatusCode))
+                {
+                    return response;
+                }
+
+                var redirectLimit = redirectOptions?.MaxAutomaticRedirections ?? maxRedirects;
+                if (currentRedirectCount >= redirectLimit)
+                {
+                    response.Dispose();
+                    throw new HttpRequestException("Maximum automatic redirections exceeded.");
+                }
+
+                var location = response.Headers.Location;
+                if (location == null)
+                {
+                    return response;
+                }
+
+                var newUri = location.IsAbsoluteUri ? location : new Uri(uri, location);
+                var newRequest = await HttpRequestStringifier.CloneWithRedirectAsync(currentRequest, newUri, response.StatusCode).ConfigureAwait(false);
+
+                if (redirectOptions != null)
+                {
+                    newRequest.SetMojaveOptions(redirectOptions);
+                }
+                else
+                {
+                    newRequest.SetMojaveOptions(null);
+                }
+
+                response.Dispose();
+                currentRequest = newRequest;
+                currentRedirectCount++;
+            }
+        }
+
+        private static bool IsRedirect(HttpStatusCode statusCode)
+        {
+            return statusCode == HttpStatusCode.Moved ||
+                   statusCode == HttpStatusCode.Redirect ||
+                   statusCode == HttpStatusCode.RedirectMethod ||
+                   statusCode == HttpStatusCode.TemporaryRedirect ||
+                   (int)statusCode == 308;
+        }
+
+        private static bool ShouldUseHttp2(HttpRequestMessage request)
+        {
+            if (request?.Version == null)
+            {
+                return false;
             }
 
+            return request.Version.Major >= 2;
+        }
+
+        private async Task<HttpResponseMessage> SendHttp11Async(
+            HttpRequestMessage request,
+            Uri uri,
+            bool useTls,
+            TimeSpan timeout,
+            JA3Fingerprint fingerprint,
+            MojaveTlsSettings tlsSettings,
+            MojaveProxyOptions proxyOptions,
+            CancellationToken cancellationToken)
+        {
             var requestPayload = await HttpRequestStringifier.Stringify(request).ConfigureAwait(false);
 
             using var tlsClient = new TlsClient(
@@ -71,51 +154,216 @@ namespace Moljave.Http
                 _options.CertificateValidationCallback);
 
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            linkedCts.CancelAfter(effectiveTimeout);
-
-            var responseBytes = await tlsClient.SendRequestAsync(
-                requestPayload,
-                linkedCts.Token,
-                useTls).ConfigureAwait(false);
-
-            var response = HttpResponseParser.Parse(responseBytes);
-
-            if (cookieManager != null && response.Headers.TryGetValues("Set-Cookie", out var setCookieHeaders))
+            if (timeout > TimeSpan.Zero)
             {
-                cookieManager.UpdateFromSetCookieHeaders(uri, setCookieHeaders);
+                linkedCts.CancelAfter(timeout);
             }
 
-            if (allowRedirect && IsRedirect(response.StatusCode))
+            try
             {
-                if (redirectCount >= maxRedirects)
-                {
-                    throw new HttpRequestException("Maximum automatic redirections exceeded.");
-                }
-
-                var location = response.Headers.Location;
-                if (location != null)
-                {
-                    var newUri = location.IsAbsoluteUri ? location : new Uri(uri, location);
-                    var newRequest = await HttpRequestStringifier.CloneWithRedirectAsync(
-                        request,
-                        newUri,
-                        response.StatusCode).ConfigureAwait(false);
-                    newRequest.SetMojaveOptions(request.GetMojaveOptions()?.Clone());
-                    response.Dispose();
-                    return await SendAsyncInternal(newRequest, cancellationToken, redirectCount + 1).ConfigureAwait(false);
-                }
+                var responseBytes = await tlsClient.SendRequestAsync(requestPayload, linkedCts.Token, useTls).ConfigureAwait(false);
+                var response = HttpResponseParser.Parse(responseBytes);
+                response.RequestMessage = request;
+                return response;
             }
-
-            return response;
+            catch (OperationCanceledException) when (linkedCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException("The HTTP/1.1 request timed out.");
+            }
         }
 
-        private static bool IsRedirect(HttpStatusCode statusCode)
+        private async Task<HttpResponseMessage> SendHttp2Async(
+            HttpRequestMessage request,
+            Uri uri,
+            TimeSpan timeout,
+            JA3Fingerprint fingerprint,
+            MojaveTlsSettings tlsSettings,
+            MojaveProxyOptions proxyOptions,
+            CancellationToken cancellationToken)
         {
-            return statusCode == HttpStatusCode.Moved ||
-                   statusCode == HttpStatusCode.Redirect ||
-                   statusCode == HttpStatusCode.RedirectMethod ||
-                   statusCode == HttpStatusCode.TemporaryRedirect ||
-                   (int)statusCode == 308;
+            using var handler = CreateHttp2Handler(uri, fingerprint, tlsSettings, proxyOptions);
+            using var invoker = new HttpMessageInvoker(handler, disposeHandler: true);
+            var http2Request = await CloneHttpRequestForHttp2Async(request).ConfigureAwait(false);
+
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            if (timeout > TimeSpan.Zero)
+            {
+                linkedCts.CancelAfter(timeout);
+            }
+
+            try
+            {
+                var response = await invoker.SendAsync(http2Request, linkedCts.Token).ConfigureAwait(false);
+
+                using (response)
+                {
+                    var bodyBytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                    var finalResponse = new HttpResponseMessage(response.StatusCode)
+                    {
+                        Version = response.Version,
+                        ReasonPhrase = response.ReasonPhrase,
+                        RequestMessage = request
+                    };
+
+                    foreach (var header in response.Headers)
+                    {
+                        finalResponse.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    }
+
+                    var contentHeaders = new List<KeyValuePair<string, string>>();
+                    foreach (var header in response.Content.Headers)
+                    {
+                        contentHeaders.Add(new KeyValuePair<string, string>(header.Key, string.Join(", ", header.Value)));
+                    }
+
+                    finalResponse.Content = HttpContentUtilities.CreateContent(bodyBytes, contentHeaders, out _);
+                    return finalResponse;
+                }
+            }
+            catch (OperationCanceledException) when (linkedCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException("The HTTP/2 request timed out.");
+            }
+        }
+
+        private async Task<HttpRequestMessage> CloneHttpRequestForHttp2Async(HttpRequestMessage request)
+        {
+            var clone = new HttpRequestMessage(request.Method, request.RequestUri)
+            {
+                Version = request.Version
+            };
+
+            HttpRequestStringifier.CopyVersionPolicy(request, clone);
+
+            foreach (var header in request.Headers)
+            {
+                clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            if (request.Content != null)
+            {
+                clone.Content = await request.Content.BufferAsync().ConfigureAwait(false);
+                foreach (var header in request.Content.Headers)
+                {
+                    clone.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+            }
+
+            return clone;
+        }
+
+        private HttpMessageHandler CreateHttp2Handler(
+            Uri uri,
+            JA3Fingerprint fingerprint,
+            MojaveTlsSettings tlsSettings,
+            MojaveProxyOptions proxyOptions)
+        {
+            var handler = new SocketsHttpHandler
+            {
+                AllowAutoRedirect = false,
+                AutomaticDecompression = DecompressionMethods.None,
+                UseCookies = false,
+                EnableMultipleHttp2Connections = true
+            };
+
+            handler.SslOptions = BuildHttp2SslOptions(uri.Host, fingerprint, tlsSettings);
+
+            if (proxyOptions?.Descriptor != null)
+            {
+                switch (proxyOptions.Descriptor.Scheme)
+                {
+                    case ProxyScheme.Http:
+                    case ProxyScheme.Https:
+                        handler.Proxy = proxyOptions.Descriptor.ToWebProxy();
+                        handler.UseProxy = true;
+                        break;
+                    default:
+                        handler.UseProxy = false;
+                        handler.ConnectCallback = async (context, token) =>
+                        {
+                            var connector = new TlsClient(
+                                context.DnsEndPoint.Host,
+                                context.DnsEndPoint.Port,
+                                fingerprint,
+                                proxyOptions.Descriptor,
+                                tlsSettings,
+                                _options.CertificateValidationCallback);
+
+                            var stream = await connector.CreateTransportStreamAsync(token).ConfigureAwait(false);
+                            return new TlsClientTransportStream(connector, stream);
+                        };
+                        break;
+                }
+            }
+            else
+            {
+                handler.UseProxy = false;
+            }
+
+            return handler;
+        }
+
+        private SslClientAuthenticationOptions BuildHttp2SslOptions(
+            string host,
+            JA3Fingerprint fingerprint,
+            MojaveTlsSettings tlsSettings)
+        {
+            var sslProtocols = tlsSettings.EnabledProtocols ?? fingerprint.GetSslProtocols();
+            var cipherSuites = fingerprint.GetCipherSuites();
+            var configuredProtocols = tlsSettings.ApplicationProtocols ?? fingerprint.GetApplicationProtocols();
+
+            var sslOptions = new SslClientAuthenticationOptions
+            {
+                TargetHost = host,
+                EnabledSslProtocols = sslProtocols,
+                EncryptionPolicy = EncryptionPolicy.RequireEncryption,
+                ClientCertificates = new System.Security.Cryptography.X509Certificates.X509CertificateCollection()
+            };
+
+            if (cipherSuites?.Length > 0)
+            {
+                sslOptions.CipherSuitesPolicy = new CipherSuitesPolicy(cipherSuites);
+            }
+
+            var protocols = new List<SslApplicationProtocol>();
+            var hasHttp2 = false;
+            var hasHttp11 = false;
+
+            if (configuredProtocols != null)
+            {
+                foreach (var protocol in configuredProtocols)
+                {
+                    if (protocol.Equals("h2", StringComparison.OrdinalIgnoreCase))
+                    {
+                        hasHttp2 = true;
+                    }
+
+                    if (protocol.Equals("http/1.1", StringComparison.OrdinalIgnoreCase))
+                    {
+                        hasHttp11 = true;
+                    }
+
+                    protocols.Add(new SslApplicationProtocol(Encoding.ASCII.GetBytes(protocol)));
+                }
+            }
+
+            if (!hasHttp2)
+            {
+                protocols.Insert(0, SslApplicationProtocol.Http2);
+            }
+
+            if (!hasHttp11)
+            {
+                protocols.Add(SslApplicationProtocol.Http11);
+            }
+
+            sslOptions.ApplicationProtocols = protocols;
+
+            sslOptions.RemoteCertificateValidationCallback = tlsSettings.ValidateCertificate
+                ? tlsSettings.CertificateValidationCallback ?? _options.CertificateValidationCallback
+                : _options.CertificateValidationCallback;
+
+            return sslOptions;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - **Per-request overrides** — change proxy/TLS/fingerprint/timeout for individual calls
 - **Custom headers** — send and control order like a browser
 - **Auto-decompression** — supports gzip, deflate, br (brotli)
-- **Raw HTTP/1.1 request/response** — maximum control
+- **Raw HTTP/1.1 & HTTP/2 request/response** — maximum control with on-the-fly protocol selection
 - **Async/await** — modern, fast, thread-safe
 - **Easy to extend** — add more fingerprints or features
 

--- a/TlsClient.cs
+++ b/TlsClient.cs
@@ -54,30 +54,7 @@ namespace Moljave.Http
                 throw new ArgumentNullException(nameof(requestBytes));
             }
 
-            _tcpClient = new TcpClient
-            {
-                NoDelay = true
-            };
-
-            if (_proxy == null)
-            {
-                await _tcpClient.ConnectAsync(_host, _port).WaitAsync(cancellationToken).ConfigureAwait(false);
-                _transportStream = _tcpClient.GetStream();
-            }
-            else
-            {
-                await ConnectThroughProxyAsync(cancellationToken).ConfigureAwait(false);
-            }
-
-            var activeStream = _transportStream;
-
-            if (useTls)
-            {
-                _sslStream = new SslStream(activeStream, leaveInnerStreamOpen: false, GetValidationCallback());
-                var authenticationOptions = BuildAuthenticationOptions();
-                await _sslStream.AuthenticateAsClientAsync(authenticationOptions, cancellationToken).ConfigureAwait(false);
-                activeStream = _sslStream;
-            }
+            var activeStream = await GetActiveStreamAsync(useTls, cancellationToken).ConfigureAwait(false);
 
             await activeStream.WriteAsync(requestBytes, 0, requestBytes.Length, cancellationToken).ConfigureAwait(false);
             await activeStream.FlushAsync(cancellationToken).ConfigureAwait(false);
@@ -140,6 +117,56 @@ namespace Moljave.Http
             }
 
             return memoryStream.ToArray();
+        }
+
+        public async Task<Stream> CreateTransportStreamAsync(CancellationToken cancellationToken)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TlsClient));
+            }
+
+            if (_transportStream != null)
+            {
+                return _transportStream;
+            }
+
+            _tcpClient = new TcpClient
+            {
+                NoDelay = true
+            };
+
+            if (_proxy == null)
+            {
+                await _tcpClient.ConnectAsync(_host, _port).WaitAsync(cancellationToken).ConfigureAwait(false);
+                _transportStream = _tcpClient.GetStream();
+            }
+            else
+            {
+                await ConnectThroughProxyAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            return _transportStream;
+        }
+
+        private async Task<Stream> GetActiveStreamAsync(bool useTls, CancellationToken cancellationToken)
+        {
+            var transportStream = await CreateTransportStreamAsync(cancellationToken).ConfigureAwait(false);
+
+            if (!useTls)
+            {
+                return transportStream;
+            }
+
+            if (_sslStream != null)
+            {
+                return _sslStream;
+            }
+
+            _sslStream = new SslStream(transportStream, leaveInnerStreamOpen: false, GetValidationCallback());
+            var authenticationOptions = BuildAuthenticationOptions();
+            await _sslStream.AuthenticateAsClientAsync(authenticationOptions, cancellationToken).ConfigureAwait(false);
+            return _sslStream;
         }
 
         private async Task ConnectThroughProxyAsync(CancellationToken cancellationToken)

--- a/TlsClientTransportStream.cs
+++ b/TlsClientTransportStream.cs
@@ -1,0 +1,72 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Moljave.Http
+{
+    internal sealed class TlsClientTransportStream : Stream
+    {
+        private readonly TlsClient _client;
+        private readonly Stream _innerStream;
+        private bool _disposed;
+
+        public TlsClientTransportStream(TlsClient client, Stream innerStream)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+            _innerStream = innerStream ?? throw new ArgumentNullException(nameof(innerStream));
+        }
+
+        public override bool CanRead => _innerStream.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => _innerStream.CanWrite;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => _innerStream.Flush();
+
+        public override Task FlushAsync(CancellationToken cancellationToken) => _innerStream.FlushAsync(cancellationToken);
+
+        public override int Read(byte[] buffer, int offset, int count) => _innerStream.Read(buffer, offset, count);
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => _innerStream.ReadAsync(buffer, offset, count, cancellationToken);
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => _innerStream.ReadAsync(buffer, cancellationToken);
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => _innerStream.Write(buffer, offset, count);
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => _innerStream.WriteAsync(buffer, offset, count, cancellationToken);
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            => _innerStream.WriteAsync(buffer, cancellationToken);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                _innerStream.Dispose();
+                _client.Dispose();
+            }
+
+            _disposed = true;
+            base.Dispose(disposing);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated HTTP/2 send path with timeout-aware handling, shared content decoding, and reusable transport streams
- fix Mojave request option removal and preserve HTTP version metadata across redirects
- surface timeout exceptions instead of generic cancellations and document HTTP/2 support in the README

## Testing
- not run (no automated tests provided)

------
https://chatgpt.com/codex/tasks/task_e_68ee6437bff88332ad91c2a89a6831da