### PR TITLE
Handle unsupported cipher suites and platform limitations

### DIFF
--- a/CipherSuiteConverter.cs
+++ b/CipherSuiteConverter.cs
@@ -25,9 +25,26 @@ namespace Moljave.Http
             { 53, TlsCipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA }
         };
 
+        public static bool TryGetCipherSuite(int cipherSuiteId, out TlsCipherSuite cipherSuite)
+        {
+            if (_cipherSuiteMap.TryGetValue(cipherSuiteId, out cipherSuite))
+            {
+                return true;
+            }
+
+            if (cipherSuiteId >= 0 && cipherSuiteId <= ushort.MaxValue)
+            {
+                cipherSuite = (TlsCipherSuite)(ushort)cipherSuiteId;
+                return true;
+            }
+
+            cipherSuite = default;
+            return false;
+        }
+
         public static TlsCipherSuite GetCipherSuite(int cipherSuiteId)
         {
-            if (_cipherSuiteMap.TryGetValue(cipherSuiteId, out var cipherSuite)) return cipherSuite;
+            if (TryGetCipherSuite(cipherSuiteId, out var cipherSuite)) return cipherSuite;
             throw new ArgumentException($"Unsupported cipher suite ID: {cipherSuiteId}", nameof(cipherSuiteId));
         }
     }

--- a/JA3Fingerprint.cs
+++ b/JA3Fingerprint.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Security;
 using System.Security.Authentication;
@@ -44,7 +45,21 @@ namespace Moljave.Http
 
         public TlsCipherSuite[] GetCipherSuites()
         {
-            return CipherSuites.Select(CipherSuiteConverter.GetCipherSuite).ToArray();
+            if (CipherSuites == null || CipherSuites.Length == 0)
+            {
+                return Array.Empty<TlsCipherSuite>();
+            }
+
+            var supportedSuites = new List<TlsCipherSuite>(CipherSuites.Length);
+            foreach (var cipherSuiteId in CipherSuites)
+            {
+                if (CipherSuiteConverter.TryGetCipherSuite(cipherSuiteId, out var cipherSuite))
+                {
+                    supportedSuites.Add(cipherSuite);
+                }
+            }
+
+            return supportedSuites.ToArray();
         }
 
         public string[] GetApplicationProtocols()

--- a/MojaveHttpMessageHandler.cs
+++ b/MojaveHttpMessageHandler.cs
@@ -322,7 +322,14 @@ namespace Moljave.Http
 
             if (cipherSuites?.Length > 0)
             {
-                sslOptions.CipherSuitesPolicy = new CipherSuitesPolicy(cipherSuites);
+                try
+                {
+                    sslOptions.CipherSuitesPolicy = new CipherSuitesPolicy(cipherSuites);
+                }
+                catch (PlatformNotSupportedException)
+                {
+                    // The current platform does not support configuring cipher suites.
+                }
             }
 
             var protocols = new List<SslApplicationProtocol>();

--- a/TlsClient.cs
+++ b/TlsClient.cs
@@ -523,7 +523,14 @@ namespace Moljave.Http
             var cipherSuites = _fingerprint.GetCipherSuites();
             if (cipherSuites?.Length > 0)
             {
-                options.CipherSuitesPolicy = new CipherSuitesPolicy(cipherSuites);
+                try
+                {
+                    options.CipherSuitesPolicy = new CipherSuitesPolicy(cipherSuites);
+                }
+                catch (PlatformNotSupportedException)
+                {
+                    // The current platform does not support configuring cipher suites.
+                }
             }
 
             if (applicationProtocols != null)


### PR DESCRIPTION
## Summary
- allow JA3 fingerprints to ignore cipher suites that are not supported by the runtime
- fall back to numeric conversion when mapping cipher suite identifiers
- guard CipherSuitesPolicy configuration so unsupported platforms continue without throwing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68eee7760adc8332a985bcb9d79570ee