### PR TITLE
Fix HTTP/1.1 redirect responses with zero-length bodies

### DIFF
--- a/TlsClient.cs
+++ b/TlsClient.cs
@@ -87,12 +87,14 @@ namespace Moljave.Http
 
             var headersText = Encoding.ASCII.GetString(headerBytes);
             int contentLength = 0;
+            bool hasContentLength = false;
             bool isChunked = false;
 
             foreach (var line in headersText.Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries))
             {
                 if (line.StartsWith("Content-Length:", StringComparison.OrdinalIgnoreCase))
                 {
+                    hasContentLength = true;
                     int.TryParse(line[15..].Trim(), out contentLength);
                 }
 
@@ -107,7 +109,7 @@ namespace Moljave.Http
             {
                 await ReadChunkedBodyAsync(activeStream, memoryStream, cancellationToken).ConfigureAwait(false);
             }
-            else if (contentLength > 0)
+            else if (hasContentLength)
             {
                 await ReadFixedBodyAsync(activeStream, memoryStream, contentLength, cancellationToken).ConfigureAwait(false);
             }


### PR DESCRIPTION
## Summary
- ensure the HTTP/1.1 client honors Content-Length headers even when zero
- avoid waiting for the server to close the connection when a zero-length body is specified

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eee927d98c833291795f0ed7c11cc5