### PR TITLE
Reduce socket exhaustion when connecting via proxy

### DIFF
--- a/TlsClient.cs
+++ b/TlsClient.cs
@@ -138,8 +138,19 @@ namespace Moljave.Http
                 NoDelay = true,
                 ReceiveBufferSize = 64 * 1024,
                 SendBufferSize = 64 * 1024,
-                LingerState = new LingerOption(enable: false, seconds: 0)
+                // Use an abortive close so sockets do not pile up in TIME_WAIT when running at high volume.
+                LingerState = new LingerOption(enable: true, seconds: 0)
             };
+
+            try
+            {
+                // Allow quickly reusing ephemeral ports on platforms that support it to avoid hitting per-process limits.
+                _tcpClient.Client?.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, optionValue: true);
+            }
+            catch (SocketException)
+            {
+                // Some platforms do not allow adjusting the reuse option on TCP clients.
+            }
 
             if (_proxy == null)
             {


### PR DESCRIPTION
## Summary
- switch the TLS transport to abortively close sockets so they do not accumulate in TIME_WAIT
- attempt to reuse ephemeral ports when possible to avoid hitting per-process socket limits during heavy proxy usage

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ef0ba9557c8332b931046ee5203ab8