### PR TITLE
Add pooled TLS connection reuse to avoid proxy exhaustion

### DIFF
--- a/MojaveHttpClientOptions.cs
+++ b/MojaveHttpClientOptions.cs
@@ -13,6 +13,7 @@ namespace Moljave.Http
         private int _maxConnectionRetries = 2;
         private TimeSpan _connectionRetryDelay = TimeSpan.FromMilliseconds(150);
         private int _maxConnectionsPerHost = 6000;
+        private int _maxRequestsPerConnection = 32;
 
         public Func<JA3Fingerprint> FingerprintProvider { get; set; } =
             () => JA3FingerprintFactory.GetFingerprint(BrowserJa3Profile.Chrome);
@@ -37,6 +38,8 @@ namespace Moljave.Http
         }
 
         public bool AllowAutoRedirect { get; set; } = true;
+
+        public bool EnableConnectionPooling { get; set; } = true;
 
         public int MaxAutomaticRedirections
         {
@@ -66,6 +69,12 @@ namespace Moljave.Http
         {
             get => _maxConnectionsPerHost;
             set => _maxConnectionsPerHost = value <= 0 ? 1 : value;
+        }
+
+        public int MaxRequestsPerConnection
+        {
+            get => _maxRequestsPerConnection;
+            set => _maxRequestsPerConnection = value <= 0 ? 1 : value;
         }
 
         public IList<Func<DelegatingHandler>> DelegatingHandlerFactories { get; } = new List<Func<DelegatingHandler>>();

--- a/MojaveHttpMessageHandler.cs
+++ b/MojaveHttpMessageHandler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Security;
@@ -156,16 +157,30 @@ namespace Moljave.Http
             var requestPayload = await HttpRequestStringifier.Stringify(request).ConfigureAwait(false);
 
             Exception lastException = null;
+            var port = uri.IsDefaultPort ? (useTls ? 443 : 80) : uri.Port;
 
             for (int attempt = 0; attempt <= maxRetries; attempt++)
             {
-                using var tlsClient = new TlsClient(
-                    uri.Host,
-                    uri.IsDefaultPort ? (useTls ? 443 : 80) : uri.Port,
-                    fingerprint,
-                    proxyOptions?.Descriptor,
-                    tlsSettings,
-                    _options.CertificateValidationCallback);
+                using var lease = _options.EnableConnectionPooling
+                    ? TlsClientPool.Rent(
+                        uri.Host,
+                        port,
+                        useTls,
+                        fingerprint,
+                        proxyOptions?.Descriptor,
+                        tlsSettings,
+                        _options.CertificateValidationCallback,
+                        _options.MaxRequestsPerConnection,
+                        _options.MaxConnectionsPerHost)
+                    : TlsClientLease.CreateUnpooled(new TlsClient(
+                        uri.Host,
+                        port,
+                        fingerprint,
+                        proxyOptions?.Descriptor,
+                        tlsSettings,
+                        _options.CertificateValidationCallback));
+
+                var tlsClient = lease.Client;
 
                 using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 if (timeout > TimeSpan.Zero)
@@ -178,14 +193,22 @@ namespace Moljave.Http
                     var responseBytes = await tlsClient.SendRequestAsync(requestPayload, linkedCts.Token, useTls).ConfigureAwait(false);
                     var response = HttpResponseParser.Parse(responseBytes);
                     response.RequestMessage = request;
+
+                    if (_options.EnableConnectionPooling)
+                    {
+                        lease.SetReturnToPool(ShouldKeepConnectionAlive(request, response));
+                    }
+
                     return response;
                 }
                 catch (OperationCanceledException) when (linkedCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
                 {
+                    lease.SetReturnToPool(false);
                     throw new TimeoutException("The HTTP/1.1 request timed out.");
                 }
                 catch (Exception ex) when (ShouldRetry(ex, proxyOptions) && attempt < maxRetries)
                 {
+                    lease.SetReturnToPool(false);
                     lastException = ex;
                     await DelayForRetryAsync(attempt, retryDelay, cancellationToken).ConfigureAwait(false);
                 }
@@ -383,6 +406,69 @@ namespace Moljave.Http
             }
 
             return handler;
+        }
+
+        private static bool ShouldKeepConnectionAlive(HttpRequestMessage request, HttpResponseMessage response)
+        {
+            if (request == null || response == null)
+            {
+                return false;
+            }
+
+            if (ContainsConnectionToken(request.Headers.Connection, "close") || ContainsConnectionToken(request.Headers.Connection, "upgrade"))
+            {
+                return false;
+            }
+
+            if (HasHeaderToken(request.Headers, "Proxy-Connection", "close"))
+            {
+                return false;
+            }
+
+            if (ContainsConnectionToken(response.Headers.Connection, "close") || ContainsConnectionToken(response.Headers.Connection, "upgrade"))
+            {
+                return false;
+            }
+
+            if (HasHeaderToken(response.Headers, "Proxy-Connection", "close"))
+            {
+                return false;
+            }
+
+            return response.Version?.Major >= 1;
+        }
+
+        private static bool ContainsConnectionToken(System.Collections.Generic.IEnumerable<string> values, string token)
+        {
+            if (values == null)
+            {
+                return false;
+            }
+
+            return values.Any(value => string.Equals(value, token, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static bool HasHeaderToken(System.Net.Http.Headers.HttpHeaders headers, string headerName, string token)
+        {
+            if (headers == null)
+            {
+                return false;
+            }
+
+            if (!headers.TryGetValues(headerName, out var values))
+            {
+                return false;
+            }
+
+            foreach (var value in values)
+            {
+                if (value.Split(',').Select(part => part.Trim()).Any(part => string.Equals(part, token, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static bool ShouldRetry(Exception exception, MojaveProxyOptions proxyOptions)

--- a/TlsClient.cs
+++ b/TlsClient.cs
@@ -25,6 +25,7 @@ namespace Moljave.Http
         private Stream _transportStream;
         private SslStream _sslStream;
         private bool _disposed;
+        private int _usageCount;
 
         public TlsClient(
             string host,
@@ -53,6 +54,8 @@ namespace Moljave.Http
             {
                 throw new ArgumentNullException(nameof(requestBytes));
             }
+
+            Interlocked.Increment(ref _usageCount);
 
             var activeStream = await GetActiveStreamAsync(useTls, cancellationToken).ConfigureAwait(false);
 
@@ -662,6 +665,48 @@ namespace Moljave.Http
             _sslStream?.Dispose();
             _transportStream?.Dispose();
             _tcpClient?.Dispose();
+        }
+
+        internal bool IsConnectionReusable(int maxRequestsPerConnection)
+        {
+            if (_disposed)
+            {
+                return false;
+            }
+
+            if (maxRequestsPerConnection > 0 && Volatile.Read(ref _usageCount) >= maxRequestsPerConnection)
+            {
+                return false;
+            }
+
+            var client = _tcpClient?.Client;
+            if (client == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                if (!client.Connected)
+                {
+                    return false;
+                }
+
+                if (client.Poll(0, SelectMode.SelectRead) && client.Available == 0)
+                {
+                    return false;
+                }
+            }
+            catch (SocketException)
+            {
+                return false;
+            }
+            catch (ObjectDisposedException)
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/TlsClientPool.cs
+++ b/TlsClientPool.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Linq;
+using System.Net.Security;
+using System.Runtime.CompilerServices;
+
+namespace Moljave.Http
+{
+    internal static class TlsClientPool
+    {
+        private static readonly ConcurrentDictionary<string, ConcurrentQueue<TlsClient>> _pools = new();
+        private static readonly ConcurrentDictionary<string, int> _poolSizes = new();
+
+        public static TlsClientLease Rent(
+            string host,
+            int port,
+            bool useTls,
+            JA3Fingerprint fingerprint,
+            ProxyDescriptor proxy,
+            MojaveTlsSettings tlsSettings,
+            RemoteCertificateValidationCallback certificateValidationCallback,
+            int maxRequestsPerConnection,
+            int maxPoolSize)
+        {
+            var key = BuildKey(host, port, useTls, fingerprint, proxy, tlsSettings, certificateValidationCallback);
+
+            if (_pools.TryGetValue(key, out var queue))
+            {
+                while (queue.TryDequeue(out var pooledClient))
+                {
+                    DecrementSize(key);
+
+                    if (pooledClient.IsConnectionReusable(maxRequestsPerConnection))
+                    {
+                        return new TlsClientLease(key, pooledClient, maxRequestsPerConnection, maxPoolSize, poolingEnabled: true);
+                    }
+
+                    pooledClient.Dispose();
+                }
+            }
+
+            var client = new TlsClient(host, port, fingerprint, proxy, tlsSettings, certificateValidationCallback);
+            return new TlsClientLease(key, client, maxRequestsPerConnection, maxPoolSize, poolingEnabled: true);
+        }
+
+        internal static void Return(string key, TlsClient client, int maxRequestsPerConnection, int maxPoolSize)
+        {
+            if (maxPoolSize <= 0 || !client.IsConnectionReusable(maxRequestsPerConnection))
+            {
+                client.Dispose();
+                return;
+            }
+
+            var queue = _pools.GetOrAdd(key, _ => new ConcurrentQueue<TlsClient>());
+
+            while (true)
+            {
+                var current = _poolSizes.GetOrAdd(key, 0);
+                if (current >= maxPoolSize)
+                {
+                    client.Dispose();
+                    return;
+                }
+
+                if (_poolSizes.TryUpdate(key, current + 1, current))
+                {
+                    queue.Enqueue(client);
+                    return;
+                }
+            }
+        }
+
+        private static void DecrementSize(string key)
+        {
+            _poolSizes.AddOrUpdate(key, 0, static (_, current) => current > 0 ? current - 1 : 0);
+        }
+
+        private static string BuildKey(
+            string host,
+            int port,
+            bool useTls,
+            JA3Fingerprint fingerprint,
+            ProxyDescriptor proxy,
+            MojaveTlsSettings tlsSettings,
+            RemoteCertificateValidationCallback certificateValidationCallback)
+        {
+            var fingerprintKey = fingerprint == null
+                ? "nofp"
+                : string.Join(
+                    "|",
+                    fingerprint.SslVersion.ToString(CultureInfo.InvariantCulture),
+                    JoinInts(fingerprint.CipherSuites),
+                    JoinInts(fingerprint.Extensions),
+                    JoinInts(fingerprint.EllipticCurves),
+                    JoinInts(fingerprint.EllipticCurvePointFormats));
+
+            var tlsProtocols = tlsSettings?.EnabledProtocols?.ToString() ?? string.Empty;
+            var applicationProtocols = tlsSettings?.ApplicationProtocols?.ToArray() ?? Array.Empty<string>();
+            var applicationProtocolsKey = applicationProtocols.Length == 0
+                ? string.Empty
+                : string.Join("~", applicationProtocols);
+            var validateCertificate = tlsSettings?.ValidateCertificate ?? false;
+            var effectiveValidationCallback = validateCertificate
+                ? tlsSettings?.CertificateValidationCallback ?? certificateValidationCallback
+                : null;
+            var validationCallbackKey = effectiveValidationCallback != null
+                ? RuntimeHelpers.GetHashCode(effectiveValidationCallback).ToString(CultureInfo.InvariantCulture)
+                : "nocb";
+
+            var proxyKey = proxy == null
+                ? "noproxy"
+                : string.Join(
+                    "|",
+                    proxy.Scheme.ToString(),
+                    proxy.Host,
+                    proxy.Port.ToString(CultureInfo.InvariantCulture),
+                    proxy.ResolveHostnamesRemotely ? "1" : "0",
+                    proxy.Credentials?.UserName ?? string.Empty,
+                    proxy.Credentials?.Password ?? string.Empty);
+
+            return string.Join(
+                "::",
+                host,
+                port.ToString(CultureInfo.InvariantCulture),
+                useTls ? "tls" : "plain",
+                fingerprintKey,
+                tlsProtocols,
+                applicationProtocolsKey,
+                validateCertificate ? "validate" : "novalidate",
+                validationCallbackKey,
+                proxyKey);
+        }
+
+        private static string JoinInts(int[] values)
+        {
+            return values == null || values.Length == 0
+                ? string.Empty
+                : string.Join('-', values.Select(v => v.ToString(CultureInfo.InvariantCulture)));
+        }
+    }
+
+    internal sealed class TlsClientLease : IDisposable
+    {
+        private readonly string _key;
+        private readonly int _maxRequestsPerConnection;
+        private readonly int _maxPoolSize;
+        private readonly bool _poolingEnabled;
+        private bool _disposed;
+        private bool _returnToPool;
+
+        internal TlsClientLease(string key, TlsClient client, int maxRequestsPerConnection, int maxPoolSize, bool poolingEnabled)
+        {
+            _key = key;
+            Client = client ?? throw new ArgumentNullException(nameof(client));
+            _maxRequestsPerConnection = maxRequestsPerConnection;
+            _maxPoolSize = maxPoolSize;
+            _poolingEnabled = poolingEnabled;
+        }
+
+        public TlsClient Client { get; }
+
+        public void SetReturnToPool(bool value)
+        {
+            if (!_poolingEnabled)
+            {
+                _returnToPool = false;
+                return;
+            }
+
+            _returnToPool = value;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            if (_poolingEnabled && _returnToPool)
+            {
+                TlsClientPool.Return(_key, Client, _maxRequestsPerConnection, _maxPoolSize);
+            }
+            else
+            {
+                Client.Dispose();
+            }
+        }
+
+        public static TlsClientLease CreateUnpooled(TlsClient client)
+        {
+            return new TlsClientLease(key: null, client, maxRequestsPerConnection: 0, maxPoolSize: 0, poolingEnabled: false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable TLS client pool so HTTP/1.1 requests can share existing proxy connections instead of opening new sockets each time
- expose connection pooling toggles and per-connection reuse limits via MojaveHttpClientOptions
- track per-connection usage to safely dispose sockets that hit reuse limits or become unhealthy

## Testing
- not run (not available in repository)


------
https://chatgpt.com/codex/tasks/task_e_68ef0faeda5083329be0a8dfe76aea54