### PR TITLE
Add pooled TLS connections to reduce proxy exhaustion

### DIFF
--- a/MojaveHttpMessageHandler.cs
+++ b/MojaveHttpMessageHandler.cs
@@ -154,40 +154,81 @@ namespace Moljave.Http
             CancellationToken cancellationToken)
         {
             var requestPayload = await HttpRequestStringifier.Stringify(request).ConfigureAwait(false);
+            var requestWantsClose = RequestWantsConnectionClose(request);
+            var targetPort = uri.IsDefaultPort ? (useTls ? 443 : 80) : uri.Port;
 
             Exception lastException = null;
 
             for (int attempt = 0; attempt <= maxRetries; attempt++)
             {
-                using var tlsClient = new TlsClient(
-                    uri.Host,
-                    uri.IsDefaultPort ? (useTls ? 443 : 80) : uri.Port,
-                    fingerprint,
-                    proxyOptions?.Descriptor,
-                    tlsSettings,
-                    _options.CertificateValidationCallback);
-
-                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                if (timeout > TimeSpan.Zero)
-                {
-                    linkedCts.CancelAfter(timeout);
-                }
+                TlsClientLease lease = null;
+                CancellationTokenSource waitCts = null;
+                CancellationTokenSource linkedCts = null;
 
                 try
                 {
-                    var responseBytes = await tlsClient.SendRequestAsync(requestPayload, linkedCts.Token, useTls).ConfigureAwait(false);
+                    var waitToken = cancellationToken;
+                    if (timeout > TimeSpan.Zero)
+                    {
+                        waitCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                        waitCts.CancelAfter(timeout);
+                        waitToken = waitCts.Token;
+                    }
+
+                    lease = await TlsConnectionPool.Shared.RentAsync(
+                        uri.Host,
+                        targetPort,
+                        useTls,
+                        fingerprint,
+                        tlsSettings,
+                        proxyOptions?.Descriptor,
+                        _options.CertificateValidationCallback,
+                        _options.MaxConnectionsPerHost,
+                        waitToken).ConfigureAwait(false);
+
+                    linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    if (timeout > TimeSpan.Zero)
+                    {
+                        linkedCts.CancelAfter(timeout);
+                    }
+
+                    var responseBytes = await lease.Client.SendRequestAsync(requestPayload, linkedCts.Token, useTls).ConfigureAwait(false);
                     var response = HttpResponseParser.Parse(responseBytes);
                     response.RequestMessage = request;
+
+                    var shouldClose = requestWantsClose || ResponseIndicatesConnectionClose(response);
+                    if (shouldClose)
+                    {
+                        lease.MarkUnusable();
+                    }
+                    else
+                    {
+                        lease.MarkReusable();
+                    }
+
                     return response;
                 }
-                catch (OperationCanceledException) when (linkedCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                catch (OperationCanceledException) when (linkedCts != null && linkedCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
                 {
+                    lease?.MarkUnusable();
                     throw new TimeoutException("The HTTP/1.1 request timed out.");
+                }
+                catch (OperationCanceledException) when (waitCts != null && waitCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                {
+                    lease?.MarkUnusable();
+                    throw new TimeoutException("The HTTP/1.1 connection attempt timed out.");
                 }
                 catch (Exception ex) when (ShouldRetry(ex, proxyOptions) && attempt < maxRetries)
                 {
+                    lease?.MarkUnusable();
                     lastException = ex;
                     await DelayForRetryAsync(attempt, retryDelay, cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    linkedCts?.Dispose();
+                    waitCts?.Dispose();
+                    lease?.Dispose();
                 }
             }
 
@@ -420,6 +461,57 @@ namespace Moljave.Http
             }
 
             return exception.InnerException != null && ShouldRetry(exception.InnerException, proxyOptions);
+        }
+
+        private static bool RequestWantsConnectionClose(HttpRequestMessage request)
+        {
+            if (request == null)
+            {
+                return false;
+            }
+
+            if (request.Headers.ConnectionClose == true)
+            {
+                return true;
+            }
+
+            foreach (var value in request.Headers.Connection)
+            {
+                if (string.Equals(value, "close", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool ResponseIndicatesConnectionClose(HttpResponseMessage response)
+        {
+            if (response == null)
+            {
+                return true;
+            }
+
+            if (response.Headers.ConnectionClose == true)
+            {
+                return true;
+            }
+
+            foreach (var value in response.Headers.Connection)
+            {
+                if (string.Equals(value, "close", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            if (response.Version != null && response.Version.Major == 1 && response.Version.Minor == 0)
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private static bool IsRetryableProxyError(ProxyException proxyException)

--- a/TlsClient.cs
+++ b/TlsClient.cs
@@ -177,6 +177,43 @@ namespace Moljave.Http
             return _sslStream;
         }
 
+        public bool IsReusable
+        {
+            get
+            {
+                if (_disposed)
+                {
+                    return false;
+                }
+
+                var client = _tcpClient;
+                if (client == null)
+                {
+                    return false;
+                }
+
+                try
+                {
+                    var socket = client.Client;
+                    if (socket == null || !socket.Connected)
+                    {
+                        return false;
+                    }
+
+                    if (socket.Poll(0, SelectMode.SelectRead) && socket.Available == 0)
+                    {
+                        return false;
+                    }
+
+                    return true;
+                }
+                catch (ObjectDisposedException)
+                {
+                    return false;
+                }
+            }
+        }
+
         private static void ConfigureForHighVolumeReuse(TcpClient client)
         {
             if (client == null)
@@ -716,6 +753,9 @@ namespace Moljave.Http
             _sslStream?.Dispose();
             _transportStream?.Dispose();
             _tcpClient?.Dispose();
+            _sslStream = null;
+            _transportStream = null;
+            _tcpClient = null;
         }
     }
 }

--- a/TlsConnectionPool.cs
+++ b/TlsConnectionPool.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Security;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Moljave.Http
+{
+    internal sealed class TlsConnectionPool
+    {
+        private static readonly Lazy<TlsConnectionPool> _lazy = new(() => new TlsConnectionPool());
+
+        private readonly ConcurrentDictionary<PoolKey, PoolState> _states = new();
+
+        public static TlsConnectionPool Shared => _lazy.Value;
+
+        private TlsConnectionPool()
+        {
+        }
+
+        public async Task<TlsClientLease> RentAsync(
+            string host,
+            int port,
+            bool useTls,
+            JA3Fingerprint fingerprint,
+            MojaveTlsSettings tlsSettings,
+            ProxyDescriptor proxyDescriptor,
+            RemoteCertificateValidationCallback certificateValidationCallback,
+            int maxConnections,
+            CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(host))
+            {
+                throw new ArgumentNullException(nameof(host));
+            }
+
+            maxConnections = Math.Max(1, maxConnections);
+
+            var key = new PoolKey(
+                host,
+                port,
+                useTls,
+                BuildFingerprintSignature(fingerprint),
+                BuildTlsSignature(tlsSettings),
+                BuildProxySignature(proxyDescriptor));
+
+            var state = _states.GetOrAdd(key, _ => new PoolState());
+            var semaphore = state.GetSemaphore(maxConnections);
+
+            await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                while (state.Queue.TryDequeue(out var existing))
+                {
+                    if (existing != null && existing.IsReusable)
+                    {
+                        return new TlsClientLease(this, key, state, semaphore, existing);
+                    }
+
+                    existing?.Dispose();
+                }
+
+                var client = new TlsClient(
+                    host,
+                    port,
+                    fingerprint,
+                    proxyDescriptor,
+                    tlsSettings,
+                    certificateValidationCallback);
+
+                return new TlsClientLease(this, key, state, semaphore, client);
+            }
+            catch
+            {
+                semaphore.Release();
+                throw;
+            }
+        }
+
+        internal void Return(
+            PoolKey key,
+            PoolState state,
+            SemaphoreSlim semaphore,
+            TlsClient client,
+            bool canReuse)
+        {
+            try
+            {
+                if (canReuse && client != null && client.IsReusable)
+                {
+                    state.Queue.Enqueue(client);
+                }
+                else
+                {
+                    client?.Dispose();
+                }
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        }
+
+        private static string BuildFingerprintSignature(JA3Fingerprint fingerprint)
+        {
+            if (fingerprint == null)
+            {
+                return "none";
+            }
+
+            return string.Join('|', new[]
+            {
+                fingerprint.SslVersion.ToString(),
+                string.Join('-', fingerprint.CipherSuites ?? Array.Empty<int>()),
+                string.Join('-', fingerprint.Extensions ?? Array.Empty<int>()),
+                string.Join('-', fingerprint.EllipticCurves ?? Array.Empty<int>()),
+                string.Join('-', fingerprint.EllipticCurvePointFormats ?? Array.Empty<int>())
+            });
+        }
+
+        private static string BuildTlsSignature(MojaveTlsSettings settings)
+        {
+            if (settings == null)
+            {
+                return "default";
+            }
+
+            var protocols = settings.ApplicationProtocols != null
+                ? string.Join(',', settings.ApplicationProtocols)
+                : string.Empty;
+
+            return string.Join('|', new[]
+            {
+                settings.EnabledProtocols?.ToString() ?? string.Empty,
+                protocols,
+                settings.ValidateCertificate.ToString()
+            });
+        }
+
+        private static string BuildProxySignature(ProxyDescriptor descriptor)
+        {
+            if (descriptor == null)
+            {
+                return "no-proxy";
+            }
+
+            var credential = descriptor.Credentials;
+            var username = credential?.UserName ?? string.Empty;
+            var password = credential?.Password ?? string.Empty;
+
+            return string.Join('|', new[]
+            {
+                descriptor.Scheme.ToString(),
+                descriptor.Host,
+                descriptor.Port.ToString(),
+                username,
+                password,
+                descriptor.ResolveHostnamesRemotely.ToString()
+            });
+        }
+
+        internal readonly struct PoolKey : IEquatable<PoolKey>
+        {
+            public PoolKey(string host, int port, bool useTls, string fingerprintSignature, string tlsSignature, string proxySignature)
+            {
+                Host = host;
+                Port = port;
+                UseTls = useTls;
+                FingerprintSignature = fingerprintSignature;
+                TlsSignature = tlsSignature;
+                ProxySignature = proxySignature;
+            }
+
+            public string Host { get; }
+            public int Port { get; }
+            public bool UseTls { get; }
+            public string FingerprintSignature { get; }
+            public string TlsSignature { get; }
+            public string ProxySignature { get; }
+
+            public bool Equals(PoolKey other)
+            {
+                return Port == other.Port &&
+                    UseTls == other.UseTls &&
+                    string.Equals(Host, other.Host, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(FingerprintSignature, other.FingerprintSignature, StringComparison.Ordinal) &&
+                    string.Equals(TlsSignature, other.TlsSignature, StringComparison.Ordinal) &&
+                    string.Equals(ProxySignature, other.ProxySignature, StringComparison.Ordinal);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is PoolKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                var hash = new HashCode();
+                hash.Add(Host, StringComparer.OrdinalIgnoreCase);
+                hash.Add(Port);
+                hash.Add(UseTls);
+                hash.Add(FingerprintSignature, StringComparer.Ordinal);
+                hash.Add(TlsSignature, StringComparer.Ordinal);
+                hash.Add(ProxySignature, StringComparer.Ordinal);
+                return hash.ToHashCode();
+            }
+        }
+
+        internal sealed class PoolState
+        {
+            private readonly ConcurrentQueue<TlsClient> _queue = new();
+            private SemaphoreSlim _semaphore;
+            private int _maxConnections;
+
+            public ConcurrentQueue<TlsClient> Queue => _queue;
+
+            public SemaphoreSlim GetSemaphore(int maxConnections)
+            {
+                if (_semaphore == null)
+                {
+                    lock (this)
+                    {
+                        _semaphore ??= new SemaphoreSlim(maxConnections, maxConnections);
+                        _maxConnections = maxConnections;
+                    }
+                }
+                else if (maxConnections > _maxConnections)
+                {
+                    lock (this)
+                    {
+                        if (maxConnections > _maxConnections)
+                        {
+                            var difference = maxConnections - _maxConnections;
+                            _semaphore.Release(difference);
+                            _maxConnections = maxConnections;
+                        }
+                    }
+                }
+
+                return _semaphore;
+            }
+        }
+    }
+
+    internal sealed class TlsClientLease : IDisposable
+    {
+        private readonly TlsConnectionPool _pool;
+        private readonly TlsConnectionPool.PoolKey _key;
+        private readonly TlsConnectionPool.PoolState _state;
+        private readonly SemaphoreSlim _semaphore;
+        private bool _disposed;
+        private bool _canReuse;
+
+        public TlsClientLease(
+            TlsConnectionPool pool,
+            TlsConnectionPool.PoolKey key,
+            TlsConnectionPool.PoolState state,
+            SemaphoreSlim semaphore,
+            TlsClient client)
+        {
+            _pool = pool ?? throw new ArgumentNullException(nameof(pool));
+            _key = key;
+            _state = state ?? throw new ArgumentNullException(nameof(state));
+            _semaphore = semaphore ?? throw new ArgumentNullException(nameof(semaphore));
+            Client = client ?? throw new ArgumentNullException(nameof(client));
+            _canReuse = false;
+        }
+
+        public TlsClient Client { get; }
+
+        public void MarkReusable()
+        {
+            _canReuse = true;
+        }
+
+        public void MarkUnusable()
+        {
+            _canReuse = false;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _pool.Return(_key, _state, _semaphore, Client, _canReuse);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared TLS connection pool so multiple requests reuse existing sockets and respect per-host limits
- update the HTTP/1.1 handler to lease pooled connections, honour connection close semantics, and avoid proxy exhaustion
- expose an `IsReusable` check on `TlsClient` so pooled connections are only recycled when still healthy

## Testing
- `dotnet build` *(fails: `dotnet` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ef17162bb48332bc4c1044677c5c3c