### PR TITLE
Handle unsupported cipher suites and improve HTTP/2 timeouts

### DIFF
--- a/MojaveHttpMessageHandler.cs
+++ b/MojaveHttpMessageHandler.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Security;
 using System.Net.Sockets;
+using System.Reflection;
 using System.Security.Authentication;
 using System.Text;
 using System.Threading;
@@ -14,6 +15,9 @@ namespace Moljave.Http
 {
     internal sealed class MojaveHttpMessageHandler : HttpMessageHandler
     {
+        private static readonly Lazy<PropertyInfo> s_connectTimeoutProperty = new(() =>
+            typeof(SocketsHttpHandler).GetProperty("ConnectTimeout", BindingFlags.Public | BindingFlags.Instance));
+
         private readonly MojaveHttpClientOptions _options;
         public MojaveHttpMessageHandler(MojaveHttpClientOptions options)
         {
@@ -218,11 +222,26 @@ namespace Moljave.Http
                     lease?.MarkUnusable();
                     throw new TimeoutException("The HTTP/1.1 connection attempt timed out.");
                 }
-                catch (Exception ex) when (ShouldRetry(ex, proxyOptions) && attempt < maxRetries)
+                catch (Exception ex)
                 {
                     lease?.MarkUnusable();
+
+                    if (TlsPlatformSupport.TryDisableCipherSuitesPolicy(ex))
+                    {
+                        lastException = ex;
+                        attempt--;
+                        continue;
+                    }
+
+                    if (attempt < maxRetries && ShouldRetry(ex, proxyOptions))
+                    {
+                        lastException = ex;
+                        await DelayForRetryAsync(attempt, retryDelay, cancellationToken).ConfigureAwait(false);
+                        continue;
+                    }
+
                     lastException = ex;
-                    await DelayForRetryAsync(attempt, retryDelay, cancellationToken).ConfigureAwait(false);
+                    throw;
                 }
                 finally
                 {
@@ -251,10 +270,7 @@ namespace Moljave.Http
             for (int attempt = 0; attempt <= maxRetries; attempt++)
             {
                 using var handler = CreateHttp2Handler(uri, fingerprint, tlsSettings, proxyOptions);
-                if (timeout > TimeSpan.Zero)
-                {
-                    handler.ConnectTimeout = timeout;
-                }
+                ApplyHttp2ConnectTimeout(handler, timeout);
 
                 using var invoker = new HttpMessageInvoker(handler, disposeHandler: true);
                 var http2Request = await CloneHttpRequestForHttp2Async(request).ConfigureAwait(false);
@@ -298,8 +314,21 @@ namespace Moljave.Http
                 {
                     throw new TimeoutException("The HTTP/2 request timed out.");
                 }
-                catch (AuthenticationException ex) when (proxyOptions?.Descriptor != null)
+                catch (AuthenticationException ex)
                 {
+                    if (TlsPlatformSupport.TryDisableCipherSuitesPolicy(ex))
+                    {
+                        lastException = ex;
+                        attempt--;
+                        continue;
+                    }
+
+                    if (proxyOptions?.Descriptor == null)
+                    {
+                        lastException = ex;
+                        throw;
+                    }
+
                     var proxyException = new ProxyException(
                         "Failed to establish a secure connection through the proxy.",
                         ProxyErrorReason.ConnectionFailed,
@@ -316,6 +345,13 @@ namespace Moljave.Http
                 }
                 catch (HttpRequestException ex)
                 {
+                    if (TlsPlatformSupport.TryDisableCipherSuitesPolicy(ex))
+                    {
+                        lastException = ex;
+                        attempt--;
+                        continue;
+                    }
+
                     var transformed = proxyOptions?.Descriptor != null ? CreateProxyException(ex) : ex;
                     lastException = transformed;
 
@@ -338,10 +374,24 @@ namespace Moljave.Http
 
                     throw;
                 }
-                catch (Exception ex) when (ShouldRetry(ex, proxyOptions) && attempt < maxRetries)
+                catch (Exception ex)
                 {
+                    if (TlsPlatformSupport.TryDisableCipherSuitesPolicy(ex))
+                    {
+                        lastException = ex;
+                        attempt--;
+                        continue;
+                    }
+
+                    if (attempt < maxRetries && ShouldRetry(ex, proxyOptions))
+                    {
+                        lastException = ex;
+                        await DelayForRetryAsync(attempt, retryDelay, cancellationToken).ConfigureAwait(false);
+                        continue;
+                    }
+
                     lastException = ex;
-                    await DelayForRetryAsync(attempt, retryDelay, cancellationToken).ConfigureAwait(false);
+                    throw;
                 }
             }
 
@@ -424,6 +474,69 @@ namespace Moljave.Http
             }
 
             return handler;
+        }
+
+        private static void ApplyHttp2ConnectTimeout(SocketsHttpHandler handler, TimeSpan timeout)
+        {
+            if (handler == null || timeout <= TimeSpan.Zero)
+            {
+                return;
+            }
+
+            if (TrySetConnectTimeout(handler, timeout))
+            {
+                return;
+            }
+
+            if (handler.ConnectCallback != null)
+            {
+                return;
+            }
+
+            handler.ConnectCallback = async (context, token) =>
+            {
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
+                cts.CancelAfter(timeout);
+
+                var socket = new Socket(SocketType.Stream, ProtocolType.Tcp)
+                {
+                    NoDelay = true
+                };
+
+                try
+                {
+                    await socket.ConnectAsync(context.DnsEndPoint.Host, context.DnsEndPoint.Port).WaitAsync(cts.Token).ConfigureAwait(false);
+                    return new NetworkStream(socket, ownsSocket: true);
+                }
+                catch
+                {
+                    socket.Dispose();
+                    throw;
+                }
+                finally
+                {
+                    cts.Dispose();
+                }
+            };
+        }
+
+        private static bool TrySetConnectTimeout(SocketsHttpHandler handler, TimeSpan timeout)
+        {
+            var property = s_connectTimeoutProperty.Value;
+            if (property == null || !property.CanWrite)
+            {
+                return false;
+            }
+
+            try
+            {
+                property.SetValue(handler, timeout);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         private static bool ShouldRetry(Exception exception, MojaveProxyOptions proxyOptions)

--- a/MoljaveHttpClient.cs
+++ b/MoljaveHttpClient.cs
@@ -45,7 +45,7 @@ namespace Moljave.Http
 
         public MojaveHttpClient(MojaveHttpClientOptions options)
         {
-            PlatformRequirements.EnsureWindows11();
+            PlatformRequirements.EnsureSupportedWindows();
 
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _cookieManager = _options.CookieManager ?? new MojaveCookieManager();

--- a/PlatformRequirements.cs
+++ b/PlatformRequirements.cs
@@ -4,11 +4,13 @@ namespace Moljave.Http
 {
     internal static class PlatformRequirements
     {
-        public static void EnsureWindows11()
+        public static void EnsureSupportedWindows()
         {
-            if (!OperatingSystem.IsWindows() || !OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000))
+            const int minimumBuild = 19041; // Windows 10 version 2004
+
+            if (!OperatingSystem.IsWindows() || !OperatingSystem.IsWindowsVersionAtLeast(10, 0, minimumBuild))
             {
-                throw new PlatformNotSupportedException("MojaveHttpClient supports only Windows 11 or later.");
+                throw new PlatformNotSupportedException("MojaveHttpClient requires Windows 10 version 2004 (build 19041) or newer.");
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Raw HTTP/1.1 + TLS JA3 fingerprinting + Proxy + Cookies for .NET/NET Core**
 > Modern, low-level HTTP client for advanced scraping, automation and pentesting scenarios.
-> **Production ready for Windows 11 environments.**
+> **Production ready for Windows 10/11 environments.**
 
 ---
 
@@ -12,7 +12,7 @@
 
 ## 🖥️ System Requirements
 
-- **Operating system:** Windows 11 (build 22000 or newer)
+- **Operating system:** Windows 10 version 2004 (build 19041) or newer (including Windows 11)
 - **Runtime:** .NET 6.0 or later
 
 The library validates the platform at runtime and will throw a `PlatformNotSupportedException` if it is used on unsupported operating systems. This avoids failures that were previously triggered when instantiating TLS policies on other platforms.
@@ -23,7 +23,7 @@ The library validates the platform at runtime and will throw a `PlatformNotSuppo
 
 - Build your application in **Release** configuration (`dotnet build -c Release`).
 - Run your automated tests against the Release build before deployment.
-- Ensure that all target machines run **Windows 11 build 22000+** with the latest security updates.
+- Ensure that all target machines run **Windows 10 version 2004 (build 19041) or newer** with the latest security updates.
 - Configure monitoring/telemetry around HTTP request success and failure rates.
 - Keep TLS fingerprints rotated according to your security posture with `MojaveHttpClient.RotateFingerprint()`.
 

--- a/TlsPlatformSupport.cs
+++ b/TlsPlatformSupport.cs
@@ -4,9 +4,24 @@ namespace Moljave.Http
 {
     internal static class TlsPlatformSupport
     {
-        private static readonly bool _supportsCipherSuitesPolicy = DetermineCipherSuitesPolicySupport();
+        private static int _supportsCipherSuitesPolicy = DetermineCipherSuitesPolicySupport() ? 1 : 0;
 
-        public static bool SupportsCipherSuitesPolicy() => _supportsCipherSuitesPolicy;
+        public static bool SupportsCipherSuitesPolicy() => System.Threading.Volatile.Read(ref _supportsCipherSuitesPolicy) == 1;
+
+        public static bool TryDisableCipherSuitesPolicy(Exception exception)
+        {
+            if (System.Threading.Volatile.Read(ref _supportsCipherSuitesPolicy) == 0)
+            {
+                return false;
+            }
+
+            if (!ContainsPlatformNotSupported(exception))
+            {
+                return false;
+            }
+
+            return System.Threading.Interlocked.Exchange(ref _supportsCipherSuitesPolicy, 0) == 1;
+        }
 
         private static bool DetermineCipherSuitesPolicySupport()
         {
@@ -29,6 +44,34 @@ namespace Moljave.Http
             {
                 return false;
             }
+        }
+
+        private static bool ContainsPlatformNotSupported(Exception exception)
+        {
+            if (exception == null)
+            {
+                return false;
+            }
+
+            if (exception is AggregateException aggregate)
+            {
+                foreach (var inner in aggregate.InnerExceptions)
+                {
+                    if (ContainsPlatformNotSupported(inner))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            if (exception is PlatformNotSupportedException)
+            {
+                return true;
+            }
+
+            return ContainsPlatformNotSupported(exception.InnerException);
         }
     }
 }


### PR DESCRIPTION
## Summary
- relax the runtime platform guard and documentation to support Windows 10 build 19041+
- add runtime detection that disables custom cipher suites when the OS rejects them and reuse the request loop safely
- provide an HTTP/2 connect-timeout helper that works even when SocketsHttpHandler.ConnectTimeout is unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ef22a419688332b09d80b527de1a35