### PR TITLE
Fix HTTP/2 handler return type for timeout application

### DIFF
--- a/MojaveHttpMessageHandler.cs
+++ b/MojaveHttpMessageHandler.cs
@@ -424,7 +424,7 @@ namespace Moljave.Http
             return clone;
         }
 
-        private HttpMessageHandler CreateHttp2Handler(
+        private SocketsHttpHandler CreateHttp2Handler(
             Uri uri,
             JA3Fingerprint fingerprint,
             MojaveTlsSettings tlsSettings,


### PR DESCRIPTION
## Summary
- return a concrete `SocketsHttpHandler` from `CreateHttp2Handler` so HTTP/2 timeout logic can compile

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ef25fcac148332a65cd207b971206d