### PR TITLE
Add proxy rotation support and resilient retries

### DIFF
--- a/IProxyRotationListener.cs
+++ b/IProxyRotationListener.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Moljave.Http
+{
+    internal interface IProxyRotationListener
+    {
+        void OnSuccess(MojaveProxyOptions options);
+        void OnFailure(MojaveProxyOptions options, Exception exception);
+    }
+}

--- a/MojaveHttpMessageHandler.cs
+++ b/MojaveHttpMessageHandler.cs
@@ -38,6 +38,7 @@ namespace Moljave.Http
 
             var currentRequest = request;
             var currentRedirectCount = redirectCount;
+            ProxyRotationContext proxyContext = null;
 
             while (true)
             {
@@ -45,12 +46,12 @@ namespace Moljave.Http
                 var useTls = string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
 
                 var requestOptions = currentRequest.GetMojaveOptions();
+                proxyContext ??= CreateProxyContext(requestOptions);
                 var effectiveTimeout = requestOptions?.Timeout ?? _options.DefaultTimeout;
                 var maxRedirects = requestOptions?.MaxAutomaticRedirections ?? _options.MaxAutomaticRedirections;
                 var cookieManager = requestOptions?.CookieManager ?? _options.CookieManager;
                 var fingerprint = requestOptions?.Fingerprint ?? _options.FingerprintProvider?.Invoke() ?? JA3Fingerprint.Default;
                 var tlsSettings = requestOptions?.TlsSettings ?? _options.TlsSettingsProvider?.Invoke() ?? MojaveTlsSettings.Default;
-                var proxyOptions = requestOptions?.Proxy ?? _options.ProxyResolver?.Invoke() ?? MojaveProxyOptions.NoProxy;
                 var maxRetries = Math.Max(0, requestOptions?.MaxConnectionRetries ?? _options.MaxConnectionRetries);
                 var retryDelay = requestOptions?.RetryDelay ?? _options.ConnectionRetryDelay;
                 if (retryDelay < TimeSpan.Zero)
@@ -79,8 +80,8 @@ namespace Moljave.Http
                 }
 
                 HttpResponseMessage response = ShouldUseHttp2(currentRequest)
-                    ? await SendHttp2Async(currentRequest, uri, effectiveTimeout, fingerprint, tlsSettings, proxyOptions, maxRetries, retryDelay, cancellationToken).ConfigureAwait(false)
-                    : await SendHttp11Async(currentRequest, uri, useTls, effectiveTimeout, fingerprint, tlsSettings, proxyOptions, maxRetries, retryDelay, cancellationToken).ConfigureAwait(false);
+                    ? await SendHttp2Async(currentRequest, uri, effectiveTimeout, fingerprint, tlsSettings, proxyContext, maxRetries, retryDelay, cancellationToken).ConfigureAwait(false)
+                    : await SendHttp11Async(currentRequest, uri, useTls, effectiveTimeout, fingerprint, tlsSettings, proxyContext, maxRetries, retryDelay, cancellationToken).ConfigureAwait(false);
 
                 if (cookieManager != null && response.Headers.TryGetValues("Set-Cookie", out var setCookieHeaders))
                 {
@@ -126,6 +127,17 @@ namespace Moljave.Http
             }
         }
 
+        private ProxyRotationContext CreateProxyContext(MojaveRequestOptions requestOptions)
+        {
+            if (requestOptions?.Proxy != null)
+            {
+                return ProxyRotationContext.FromOverride(requestOptions.Proxy);
+            }
+
+            var resolver = _options.ProxyResolver ?? (() => MojaveProxyOptions.NoProxy);
+            return ProxyRotationContext.FromResolver(resolver);
+        }
+
         private static bool IsRedirect(HttpStatusCode statusCode)
         {
             return statusCode == HttpStatusCode.Moved ||
@@ -152,7 +164,7 @@ namespace Moljave.Http
             TimeSpan timeout,
             JA3Fingerprint fingerprint,
             MojaveTlsSettings tlsSettings,
-            MojaveProxyOptions proxyOptions,
+            ProxyRotationContext proxyContext,
             int maxRetries,
             TimeSpan retryDelay,
             CancellationToken cancellationToken)
@@ -165,6 +177,7 @@ namespace Moljave.Http
 
             for (int attempt = 0; attempt <= maxRetries; attempt++)
             {
+                var proxyOptions = proxyContext?.GetProxyForAttempt(attempt) ?? MojaveProxyOptions.NoProxy;
                 TlsClientLease lease = null;
                 CancellationTokenSource waitCts = null;
                 CancellationTokenSource linkedCts = null;
@@ -185,7 +198,7 @@ namespace Moljave.Http
                         useTls,
                         fingerprint,
                         tlsSettings,
-                        proxyOptions?.Descriptor,
+                        proxyOptions.Descriptor,
                         _options.CertificateValidationCallback,
                         _options.MaxConnectionsPerHost,
                         waitToken).ConfigureAwait(false);
@@ -210,17 +223,22 @@ namespace Moljave.Http
                         lease.MarkReusable();
                     }
 
+                    proxyContext?.NotifySuccess(proxyOptions);
                     return response;
                 }
                 catch (OperationCanceledException) when (linkedCts != null && linkedCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
                 {
                     lease?.MarkUnusable();
-                    throw new TimeoutException("The HTTP/1.1 request timed out.");
+                    var timeoutException = new TimeoutException("The HTTP/1.1 request timed out.");
+                    proxyContext?.NotifyFailure(proxyOptions, timeoutException);
+                    throw timeoutException;
                 }
                 catch (OperationCanceledException) when (waitCts != null && waitCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
                 {
                     lease?.MarkUnusable();
-                    throw new TimeoutException("The HTTP/1.1 connection attempt timed out.");
+                    var timeoutException = new TimeoutException("The HTTP/1.1 connection attempt timed out.");
+                    proxyContext?.NotifyFailure(proxyOptions, timeoutException);
+                    throw timeoutException;
                 }
                 catch (Exception ex)
                 {
@@ -236,11 +254,13 @@ namespace Moljave.Http
                     if (attempt < maxRetries && ShouldRetry(ex, proxyOptions))
                     {
                         lastException = ex;
+                        proxyContext?.NotifyFailure(proxyOptions, ex);
                         await DelayForRetryAsync(attempt, retryDelay, cancellationToken).ConfigureAwait(false);
                         continue;
                     }
 
                     lastException = ex;
+                    proxyContext?.NotifyFailure(proxyOptions, ex);
                     throw;
                 }
                 finally
@@ -260,7 +280,7 @@ namespace Moljave.Http
             TimeSpan timeout,
             JA3Fingerprint fingerprint,
             MojaveTlsSettings tlsSettings,
-            MojaveProxyOptions proxyOptions,
+            ProxyRotationContext proxyContext,
             int maxRetries,
             TimeSpan retryDelay,
             CancellationToken cancellationToken)
@@ -269,6 +289,7 @@ namespace Moljave.Http
 
             for (int attempt = 0; attempt <= maxRetries; attempt++)
             {
+                var proxyOptions = proxyContext?.GetProxyForAttempt(attempt) ?? MojaveProxyOptions.NoProxy;
                 using var handler = CreateHttp2Handler(uri, fingerprint, tlsSettings, proxyOptions);
                 ApplyHttp2ConnectTimeout(handler, timeout);
 
@@ -307,12 +328,15 @@ namespace Moljave.Http
                         }
 
                         finalResponse.Content = HttpContentUtilities.CreateContent(bodyBytes, contentHeaders, out _);
+                        proxyContext?.NotifySuccess(proxyOptions);
                         return finalResponse;
                     }
                 }
                 catch (OperationCanceledException) when (linkedCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
                 {
-                    throw new TimeoutException("The HTTP/2 request timed out.");
+                    var timeoutException = new TimeoutException("The HTTP/2 request timed out.");
+                    proxyContext?.NotifyFailure(proxyOptions, timeoutException);
+                    throw timeoutException;
                 }
                 catch (AuthenticationException ex)
                 {
@@ -323,9 +347,10 @@ namespace Moljave.Http
                         continue;
                     }
 
-                    if (proxyOptions?.Descriptor == null)
+                    if (proxyOptions.Descriptor == null)
                     {
                         lastException = ex;
+                        proxyContext?.NotifyFailure(proxyOptions, ex);
                         throw;
                     }
 
@@ -337,10 +362,12 @@ namespace Moljave.Http
                     if (attempt < maxRetries && IsRetryableProxyError(proxyException))
                     {
                         lastException = proxyException;
+                        proxyContext?.NotifyFailure(proxyOptions, proxyException);
                         await DelayForRetryAsync(attempt, retryDelay, cancellationToken).ConfigureAwait(false);
                         continue;
                     }
 
+                    proxyContext?.NotifyFailure(proxyOptions, proxyException);
                     throw proxyException;
                 }
                 catch (HttpRequestException ex)
@@ -352,26 +379,30 @@ namespace Moljave.Http
                         continue;
                     }
 
-                    var transformed = proxyOptions?.Descriptor != null ? CreateProxyException(ex) : ex;
+                    var transformed = proxyOptions.Descriptor != null ? CreateProxyException(ex) : ex;
                     lastException = transformed;
 
                     if (transformed is ProxyException proxyException)
                     {
                         if (attempt < maxRetries && IsRetryableProxyError(proxyException))
                         {
+                            proxyContext?.NotifyFailure(proxyOptions, proxyException);
                             await DelayForRetryAsync(attempt, retryDelay, cancellationToken).ConfigureAwait(false);
                             continue;
                         }
 
+                        proxyContext?.NotifyFailure(proxyOptions, proxyException);
                         throw proxyException;
                     }
 
                     if (attempt < maxRetries && ShouldRetry(transformed, proxyOptions))
                     {
+                        proxyContext?.NotifyFailure(proxyOptions, transformed);
                         await DelayForRetryAsync(attempt, retryDelay, cancellationToken).ConfigureAwait(false);
                         continue;
                     }
 
+                    proxyContext?.NotifyFailure(proxyOptions, transformed);
                     throw;
                 }
                 catch (Exception ex)
@@ -386,11 +417,13 @@ namespace Moljave.Http
                     if (attempt < maxRetries && ShouldRetry(ex, proxyOptions))
                     {
                         lastException = ex;
+                        proxyContext?.NotifyFailure(proxyOptions, ex);
                         await DelayForRetryAsync(attempt, retryDelay, cancellationToken).ConfigureAwait(false);
                         continue;
                     }
 
                     lastException = ex;
+                    proxyContext?.NotifyFailure(proxyOptions, ex);
                     throw;
                 }
             }

--- a/MoljaveHttpClient.cs
+++ b/MoljaveHttpClient.cs
@@ -136,6 +136,19 @@ namespace Moljave.Http
             }
         }
 
+        public void UseRotatingProxyProvider(RotatingProxyProvider provider)
+        {
+            if (provider == null)
+            {
+                throw new ArgumentNullException(nameof(provider));
+            }
+
+            lock (_proxyLock)
+            {
+                _options.ProxyResolver = () => provider.GetNextProxy();
+            }
+        }
+
         public void ClearProxy() => UseProxy((WebProxy)null);
 
         public void ClearAllCookies() => _cookieManager.ClearAll();

--- a/ProxyOptions.cs
+++ b/ProxyOptions.cs
@@ -53,15 +53,28 @@ namespace Moljave.Http
         public static MojaveProxyOptions NoProxy { get; } = new(null);
 
         private MojaveProxyOptions(ProxyDescriptor descriptor)
+            : this(descriptor, null)
+        {
+        }
+
+        private MojaveProxyOptions(ProxyDescriptor descriptor, IProxyRotationListener rotationListener)
         {
             Descriptor = descriptor;
+            RotationListener = rotationListener;
         }
 
         public ProxyDescriptor Descriptor { get; }
         public bool HasProxy => Descriptor != null;
 
+        internal IProxyRotationListener RotationListener { get; }
+
         public static MojaveProxyOptions FromDescriptor(ProxyDescriptor descriptor) =>
             descriptor == null ? NoProxy : new MojaveProxyOptions(descriptor);
+
+        internal static MojaveProxyOptions CreateWithListener(
+            ProxyDescriptor descriptor,
+            IProxyRotationListener rotationListener) =>
+            descriptor == null ? NoProxy : new MojaveProxyOptions(descriptor, rotationListener);
 
         public static MojaveProxyOptions FromWebProxy(WebProxy proxy)
         {
@@ -82,6 +95,27 @@ namespace Moljave.Http
 
             var descriptor = new ProxyDescriptor(scheme, proxy.Address.Host, proxy.Address.Port, credentials);
             return new MojaveProxyOptions(descriptor);
+        }
+
+        internal static MojaveProxyOptions FromWebProxy(WebProxy proxy, IProxyRotationListener rotationListener)
+        {
+            if (proxy == null)
+            {
+                return NoProxy;
+            }
+
+            var scheme = proxy.Address.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase)
+                ? ProxyScheme.Https
+                : ProxyScheme.Http;
+
+            NetworkCredential credentials = null;
+            if (proxy.Credentials is NetworkCredential creds)
+            {
+                credentials = new NetworkCredential(creds.UserName, creds.Password);
+            }
+
+            var descriptor = new ProxyDescriptor(scheme, proxy.Address.Host, proxy.Address.Port, credentials);
+            return new MojaveProxyOptions(descriptor, rotationListener);
         }
     }
 }

--- a/ProxyRotationContext.cs
+++ b/ProxyRotationContext.cs
@@ -1,0 +1,89 @@
+using System;
+
+namespace Moljave.Http
+{
+    internal sealed class ProxyRotationContext
+    {
+        private readonly bool _isFixed;
+        private readonly Func<MojaveProxyOptions> _resolver;
+        private readonly object _lock = new();
+        private MojaveProxyOptions _cachedProxy;
+        private bool _needsRefresh;
+
+        private ProxyRotationContext(MojaveProxyOptions proxyOverride)
+        {
+            _isFixed = true;
+            _resolver = null;
+            _cachedProxy = Normalize(proxyOverride);
+            _needsRefresh = false;
+        }
+
+        private ProxyRotationContext(Func<MojaveProxyOptions> resolver)
+        {
+            _isFixed = false;
+            _resolver = resolver ?? (() => MojaveProxyOptions.NoProxy);
+            _needsRefresh = true;
+        }
+
+        public static ProxyRotationContext FromOverride(MojaveProxyOptions proxyOverride)
+            => new(proxyOverride);
+
+        public static ProxyRotationContext FromResolver(Func<MojaveProxyOptions> resolver)
+            => new(resolver);
+
+        public MojaveProxyOptions GetProxyForAttempt(int attempt)
+        {
+            if (_isFixed)
+            {
+                return _cachedProxy;
+            }
+
+            lock (_lock)
+            {
+                if (_needsRefresh || _cachedProxy == null)
+                {
+                    _cachedProxy = Resolve();
+                    _needsRefresh = false;
+                }
+
+                return _cachedProxy;
+            }
+        }
+
+        public void NotifyFailure(MojaveProxyOptions proxy, Exception exception)
+        {
+            if (!_isFixed)
+            {
+                lock (_lock)
+                {
+                    _needsRefresh = true;
+                }
+            }
+
+            proxy?.RotationListener?.OnFailure(proxy, exception);
+        }
+
+        public void NotifySuccess(MojaveProxyOptions proxy)
+        {
+            proxy?.RotationListener?.OnSuccess(proxy);
+        }
+
+        private MojaveProxyOptions Resolve()
+        {
+            try
+            {
+                return Normalize(_resolver());
+            }
+            catch (Exception ex)
+            {
+                throw new ProxyException(
+                    "The proxy resolver threw an exception.",
+                    ProxyErrorReason.Unsupported,
+                    innerException: ex);
+            }
+        }
+
+        private static MojaveProxyOptions Normalize(MojaveProxyOptions options)
+            => options ?? MojaveProxyOptions.NoProxy;
+    }
+}

--- a/RotatingProxyProvider.cs
+++ b/RotatingProxyProvider.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Moljave.Http
+{
+    /// <summary>
+    /// Provides round-robin style proxy rotation with basic cooldown support for failed proxies.
+    /// </summary>
+    public sealed class RotatingProxyProvider : IProxyRotationListener
+    {
+        private readonly MojaveProxyOptions[] _proxies;
+        private readonly ConcurrentDictionary<string, DateTimeOffset> _cooldowns;
+        private int _cursor;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RotatingProxyProvider"/> class using raw proxy strings.
+        /// </summary>
+        /// <param name="proxies">A collection of proxy definitions compatible with <see cref="ProxyParser"/>.</param>
+        /// <param name="failureCooldown">Optional cooldown duration applied after a proxy failure.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="proxies"/> is <c>null</c>.</exception>
+        public RotatingProxyProvider(IEnumerable<string> proxies, TimeSpan? failureCooldown = null)
+            : this(ParseRawProxies(proxies), failureCooldown)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RotatingProxyProvider"/> class using existing proxy options.
+        /// </summary>
+        /// <param name="proxies">A collection of <see cref="MojaveProxyOptions"/> instances.</param>
+        /// <param name="failureCooldown">Optional cooldown duration applied after a proxy failure.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="proxies"/> is <c>null</c>.</exception>
+        public RotatingProxyProvider(IEnumerable<MojaveProxyOptions> proxies, TimeSpan? failureCooldown = null)
+        {
+            if (proxies == null)
+            {
+                throw new ArgumentNullException(nameof(proxies));
+            }
+
+            var materialized = new List<MojaveProxyOptions>();
+            foreach (var proxy in proxies)
+            {
+                if (proxy?.Descriptor == null)
+                {
+                    continue;
+                }
+
+                materialized.Add(MojaveProxyOptions.CreateWithListener(proxy.Descriptor, this));
+            }
+
+            _proxies = materialized.ToArray();
+            _cooldowns = new ConcurrentDictionary<string, DateTimeOffset>(StringComparer.Ordinal);
+            _cursor = -1;
+
+            FailureCooldown = failureCooldown ?? TimeSpan.FromSeconds(15);
+        }
+
+        /// <summary>
+        /// Gets or sets the cooldown duration applied after a proxy failure. Set to <see cref="TimeSpan.Zero"/> to disable cooldowns.
+        /// </summary>
+        public TimeSpan FailureCooldown { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the provider has at least one configured proxy.
+        /// </summary>
+        public bool HasProxies => _proxies.Length > 0;
+
+        /// <summary>
+        /// Retrieves the next proxy in the rotation, skipping proxies that are in a cooldown period.
+        /// </summary>
+        /// <returns>The next <see cref="MojaveProxyOptions"/> to use, or <see cref="MojaveProxyOptions.NoProxy"/> if none are available.</returns>
+        public MojaveProxyOptions GetNextProxy()
+        {
+            if (!HasProxies)
+            {
+                return MojaveProxyOptions.NoProxy;
+            }
+
+            var snapshot = _proxies;
+            var now = DateTimeOffset.UtcNow;
+            var start = (uint)Interlocked.Increment(ref _cursor);
+            var baseIndex = (int)(start % (uint)snapshot.Length);
+
+            for (var offset = 0; offset < snapshot.Length; offset++)
+            {
+                var proxy = snapshot[(baseIndex + offset) % snapshot.Length];
+                if (proxy?.Descriptor == null)
+                {
+                    continue;
+                }
+
+                var key = BuildKey(proxy.Descriptor);
+                if (_cooldowns.TryGetValue(key, out var until) && until > now)
+                {
+                    continue;
+                }
+
+                return proxy;
+            }
+
+            return MojaveProxyOptions.NoProxy;
+        }
+
+        void IProxyRotationListener.OnSuccess(MojaveProxyOptions options)
+        {
+            if (options?.Descriptor == null)
+            {
+                return;
+            }
+
+            var key = BuildKey(options.Descriptor);
+            _cooldowns.TryRemove(key, out _);
+        }
+
+        void IProxyRotationListener.OnFailure(MojaveProxyOptions options, Exception exception)
+        {
+            if (options?.Descriptor == null)
+            {
+                return;
+            }
+
+            if (FailureCooldown <= TimeSpan.Zero)
+            {
+                return;
+            }
+
+            var key = BuildKey(options.Descriptor);
+            var until = DateTimeOffset.UtcNow.Add(FailureCooldown);
+            _cooldowns[key] = until;
+        }
+
+        private static IEnumerable<MojaveProxyOptions> ParseRawProxies(IEnumerable<string> proxies)
+        {
+            if (proxies == null)
+            {
+                throw new ArgumentNullException(nameof(proxies));
+            }
+
+            foreach (var entry in proxies)
+            {
+                if (string.IsNullOrWhiteSpace(entry))
+                {
+                    continue;
+                }
+
+                if (!ProxyParser.TryParse(entry, out var options) || options?.Descriptor == null)
+                {
+                    continue;
+                }
+
+                yield return options;
+            }
+        }
+
+        private static string BuildKey(ProxyDescriptor descriptor)
+        {
+            if (descriptor == null)
+            {
+                return string.Empty;
+            }
+
+            var credential = descriptor.Credentials;
+            var username = credential?.UserName ?? string.Empty;
+            var password = credential?.Password ?? string.Empty;
+
+            return string.Join("|", new[]
+            {
+                descriptor.Scheme.ToString(),
+                descriptor.Host,
+                descriptor.Port.ToString(),
+                username,
+                password,
+                descriptor.ResolveHostnamesRemotely.ToString()
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a rotating proxy provider with cooldown tracking and listener callbacks
- integrate proxy rotation context in the message handler to retry operations while rotating proxies on failure
- expose rotating proxy configuration on the client and extend proxy options to carry rotation listeners

## Testing
- not run (no solution file or automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68ef2afe995883328023d1cce7f8d74d