### PR TITLE
Add proxy failure logging hook

### DIFF
--- a/MojaveHttpClientOptions.cs
+++ b/MojaveHttpClientOptions.cs
@@ -22,6 +22,9 @@ namespace Moljave.Http
         public Func<MojaveProxyOptions> ProxyResolver { get; set; }
             = () => MojaveProxyOptions.NoProxy;
 
+        public Action<ProxyErrorLogEntry> ProxyErrorLogger { get; set; }
+            = null;
+
         private MojaveCookieManager _cookieManager = new();
 
         public MojaveCookieManager CookieManager

--- a/MojaveHttpMessageHandler.cs
+++ b/MojaveHttpMessageHandler.cs
@@ -231,6 +231,7 @@ namespace Moljave.Http
                     lease?.MarkUnusable();
                     var timeoutException = new TimeoutException("The HTTP/1.1 request timed out.");
                     proxyContext?.NotifyFailure(proxyOptions, timeoutException);
+                    LogProxyFailure(proxyOptions, timeoutException, attempt, willRetry: false);
                     throw timeoutException;
                 }
                 catch (OperationCanceledException) when (waitCts != null && waitCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
@@ -238,6 +239,7 @@ namespace Moljave.Http
                     lease?.MarkUnusable();
                     var timeoutException = new TimeoutException("The HTTP/1.1 connection attempt timed out.");
                     proxyContext?.NotifyFailure(proxyOptions, timeoutException);
+                    LogProxyFailure(proxyOptions, timeoutException, attempt, willRetry: false);
                     throw timeoutException;
                 }
                 catch (Exception ex)
@@ -255,12 +257,14 @@ namespace Moljave.Http
                     {
                         lastException = ex;
                         proxyContext?.NotifyFailure(proxyOptions, ex);
+                        LogProxyFailure(proxyOptions, ex, attempt, willRetry: true);
                         await DelayForRetryAsync(attempt, retryDelay, cancellationToken).ConfigureAwait(false);
                         continue;
                     }
 
                     lastException = ex;
                     proxyContext?.NotifyFailure(proxyOptions, ex);
+                    LogProxyFailure(proxyOptions, ex, attempt, willRetry: false);
                     throw;
                 }
                 finally
@@ -336,6 +340,7 @@ namespace Moljave.Http
                 {
                     var timeoutException = new TimeoutException("The HTTP/2 request timed out.");
                     proxyContext?.NotifyFailure(proxyOptions, timeoutException);
+                    LogProxyFailure(proxyOptions, timeoutException, attempt, willRetry: false);
                     throw timeoutException;
                 }
                 catch (AuthenticationException ex)
@@ -363,11 +368,13 @@ namespace Moljave.Http
                     {
                         lastException = proxyException;
                         proxyContext?.NotifyFailure(proxyOptions, proxyException);
+                        LogProxyFailure(proxyOptions, proxyException, attempt, willRetry: true);
                         await DelayForRetryAsync(attempt, retryDelay, cancellationToken).ConfigureAwait(false);
                         continue;
                     }
 
                     proxyContext?.NotifyFailure(proxyOptions, proxyException);
+                    LogProxyFailure(proxyOptions, proxyException, attempt, willRetry: false);
                     throw proxyException;
                 }
                 catch (HttpRequestException ex)
@@ -387,22 +394,26 @@ namespace Moljave.Http
                         if (attempt < maxRetries && IsRetryableProxyError(proxyException))
                         {
                             proxyContext?.NotifyFailure(proxyOptions, proxyException);
+                            LogProxyFailure(proxyOptions, proxyException, attempt, willRetry: true);
                             await DelayForRetryAsync(attempt, retryDelay, cancellationToken).ConfigureAwait(false);
                             continue;
                         }
 
                         proxyContext?.NotifyFailure(proxyOptions, proxyException);
+                        LogProxyFailure(proxyOptions, proxyException, attempt, willRetry: false);
                         throw proxyException;
                     }
 
                     if (attempt < maxRetries && ShouldRetry(transformed, proxyOptions))
                     {
                         proxyContext?.NotifyFailure(proxyOptions, transformed);
+                        LogProxyFailure(proxyOptions, transformed, attempt, willRetry: true);
                         await DelayForRetryAsync(attempt, retryDelay, cancellationToken).ConfigureAwait(false);
                         continue;
                     }
 
                     proxyContext?.NotifyFailure(proxyOptions, transformed);
+                    LogProxyFailure(proxyOptions, transformed, attempt, willRetry: false);
                     throw;
                 }
                 catch (Exception ex)
@@ -418,12 +429,14 @@ namespace Moljave.Http
                     {
                         lastException = ex;
                         proxyContext?.NotifyFailure(proxyOptions, ex);
+                        LogProxyFailure(proxyOptions, ex, attempt, willRetry: true);
                         await DelayForRetryAsync(attempt, retryDelay, cancellationToken).ConfigureAwait(false);
                         continue;
                     }
 
                     lastException = ex;
                     proxyContext?.NotifyFailure(proxyOptions, ex);
+                    LogProxyFailure(proxyOptions, ex, attempt, willRetry: false);
                     throw;
                 }
             }
@@ -685,6 +698,34 @@ namespace Moljave.Http
             var delayMilliseconds = baseDelay.TotalMilliseconds * multiplier;
             var cappedMilliseconds = Math.Min(delayMilliseconds, 2000);
             return TimeSpan.FromMilliseconds(cappedMilliseconds);
+        }
+
+        private void LogProxyFailure(MojaveProxyOptions proxyOptions, Exception exception, int attempt, bool willRetry)
+        {
+            if (exception == null)
+            {
+                return;
+            }
+
+            var logger = _options.ProxyErrorLogger;
+            if (logger == null)
+            {
+                return;
+            }
+
+            if (proxyOptions?.Descriptor == null)
+            {
+                return;
+            }
+
+            try
+            {
+                logger(new ProxyErrorLogEntry(proxyOptions, exception, attempt, willRetry));
+            }
+            catch
+            {
+                // Swallow logging failures.
+            }
         }
 
         private SslClientAuthenticationOptions BuildHttp2SslOptions(

--- a/MoljaveHttpClient.cs
+++ b/MoljaveHttpClient.cs
@@ -294,7 +294,7 @@ namespace Moljave.Http
             }
         }
 
-        private static MojaveProxyOptions InvokeResolver(Func<MojaveProxyOptions> resolver)
+        private MojaveProxyOptions InvokeResolver(Func<MojaveProxyOptions> resolver)
         {
             if (resolver == null)
             {
@@ -307,10 +307,36 @@ namespace Moljave.Http
             }
             catch (Exception ex)
             {
-                throw new ProxyException(
+                var proxyException = new ProxyException(
                     "The proxy resolver threw an exception.",
                     ProxyErrorReason.Unsupported,
                     innerException: ex);
+
+                LogProxyError(MojaveProxyOptions.NoProxy, proxyException);
+                throw proxyException;
+            }
+        }
+
+        private void LogProxyError(MojaveProxyOptions proxyOptions, Exception exception, int attempt = -1, bool willRetry = false)
+        {
+            if (exception == null)
+            {
+                return;
+            }
+
+            var logger = _options.ProxyErrorLogger;
+            if (logger == null)
+            {
+                return;
+            }
+
+            try
+            {
+                logger(new ProxyErrorLogEntry(proxyOptions, exception, attempt, willRetry));
+            }
+            catch
+            {
+                // Ignore logging failures to avoid interfering with request execution.
             }
         }
 

--- a/ProxyErrorLogEntry.cs
+++ b/ProxyErrorLogEntry.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Net;
+
+namespace Moljave.Http
+{
+    public sealed class ProxyErrorLogEntry
+    {
+        public ProxyErrorLogEntry(MojaveProxyOptions proxy, Exception exception, int attempt, bool willRetry)
+        {
+            Proxy = proxy ?? MojaveProxyOptions.NoProxy;
+            Exception = exception ?? throw new ArgumentNullException(nameof(exception));
+            Attempt = attempt;
+            WillRetry = willRetry;
+
+            if (exception is ProxyException proxyException)
+            {
+                Reason = proxyException.Reason;
+                StatusCode = proxyException.StatusCode;
+            }
+        }
+
+        public MojaveProxyOptions Proxy { get; }
+
+        public ProxyDescriptor Descriptor => Proxy?.Descriptor;
+
+        public Exception Exception { get; }
+
+        public int Attempt { get; }
+
+        public bool WillRetry { get; }
+
+        public ProxyErrorReason? Reason { get; }
+
+        public HttpStatusCode? StatusCode { get; }
+    }
+}


### PR DESCRIPTION
## Summary
- add a `ProxyErrorLogger` callback and supporting `ProxyErrorLogEntry` type for proxy diagnostics
- record proxy failures, timeouts, and resolver errors across HTTP/1.1 and HTTP/2 execution paths

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68f212f0bde88332b232b5b0565bf1d5