### PR TITLE
Refactor HTTP client for runtime configurability and proxy resilience

### DIFF
--- a/MojaveHttpClientOptions.cs
+++ b/MojaveHttpClientOptions.cs
@@ -3,16 +3,18 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Security;
+using System.Threading;
 
 namespace Moljave.Http
 {
     public sealed class MojaveHttpClientOptions
     {
-        private TimeSpan _defaultTimeout = TimeSpan.FromSeconds(30);
+        private long _defaultTimeoutTicks = TimeSpan.FromSeconds(30).Ticks;
+        private int _allowAutoRedirect = 1;
         private int _maxAutomaticRedirections = 10;
         private int _maxConnectionRetries = 2;
-        private TimeSpan _connectionRetryDelay = TimeSpan.FromMilliseconds(150);
-        private int _maxConnectionsPerHost = 6000;
+        private long _connectionRetryDelayTicks = TimeSpan.FromMilliseconds(150).Ticks;
+        private int _maxConnectionsPerHost = 15000;
 
         public Func<JA3Fingerprint> FingerprintProvider { get; set; } =
             () => JA3FingerprintFactory.GetFingerprint(BrowserJa3Profile.Chrome);
@@ -36,36 +38,60 @@ namespace Moljave.Http
             set => (_cookieManager ??= new MojaveCookieManager()).ReplaceWith(value ?? new CookieContainer());
         }
 
-        public bool AllowAutoRedirect { get; set; } = true;
+        public bool AllowAutoRedirect
+        {
+            get => Volatile.Read(ref _allowAutoRedirect) == 1;
+            set => Interlocked.Exchange(ref _allowAutoRedirect, value ? 1 : 0);
+        }
 
         public int MaxAutomaticRedirections
         {
-            get => _maxAutomaticRedirections;
-            set => _maxAutomaticRedirections = value < 0 ? 0 : value;
+            get => Volatile.Read(ref _maxAutomaticRedirections);
+            set
+            {
+                var sanitized = value < 0 ? 0 : value;
+                Interlocked.Exchange(ref _maxAutomaticRedirections, sanitized);
+            }
         }
 
         public TimeSpan DefaultTimeout
         {
-            get => _defaultTimeout;
-            set => _defaultTimeout = value <= TimeSpan.Zero ? TimeSpan.FromSeconds(30) : value;
+            get => TimeSpan.FromTicks(Volatile.Read(ref _defaultTimeoutTicks));
+            set
+            {
+                var effective = value <= TimeSpan.Zero ? TimeSpan.FromSeconds(30) : value;
+                Interlocked.Exchange(ref _defaultTimeoutTicks, effective.Ticks);
+            }
         }
 
         public int MaxConnectionRetries
         {
-            get => _maxConnectionRetries;
-            set => _maxConnectionRetries = value < 0 ? 0 : value;
+            get => Volatile.Read(ref _maxConnectionRetries);
+            set
+            {
+                var effective = value < 0 ? 0 : value;
+                Interlocked.Exchange(ref _maxConnectionRetries, effective);
+            }
         }
 
         public TimeSpan ConnectionRetryDelay
         {
-            get => _connectionRetryDelay;
-            set => _connectionRetryDelay = value < TimeSpan.Zero ? TimeSpan.Zero : value;
+            get => TimeSpan.FromTicks(Volatile.Read(ref _connectionRetryDelayTicks));
+            set
+            {
+                var effective = value < TimeSpan.Zero ? TimeSpan.Zero : value;
+                Interlocked.Exchange(ref _connectionRetryDelayTicks, effective.Ticks);
+            }
         }
 
         public int MaxConnectionsPerHost
         {
-            get => _maxConnectionsPerHost;
-            set => _maxConnectionsPerHost = value <= 0 ? 1 : value;
+            get => Volatile.Read(ref _maxConnectionsPerHost);
+            set
+            {
+                var effective = value <= 0 ? 1 : value;
+                Interlocked.Exchange(ref _maxConnectionsPerHost, effective);
+            }
         }
 
         public IList<Func<DelegatingHandler>> DelegatingHandlerFactories { get; } = new List<Func<DelegatingHandler>>();

--- a/MojaveHttpMessageHandler.cs
+++ b/MojaveHttpMessageHandler.cs
@@ -251,17 +251,19 @@ namespace Moljave.Http
                         continue;
                     }
 
-                    if (attempt < maxRetries && ShouldRetry(ex, proxyOptions))
+                    var transformed = NormalizeProxyException(ex, proxyOptions);
+
+                    if (attempt < maxRetries && ShouldRetry(transformed, proxyOptions))
                     {
-                        lastException = ex;
-                        proxyContext?.NotifyFailure(proxyOptions, ex);
+                        lastException = transformed;
+                        proxyContext?.NotifyFailure(proxyOptions, transformed);
                         await DelayForRetryAsync(attempt, retryDelay, cancellationToken).ConfigureAwait(false);
                         continue;
                     }
 
-                    lastException = ex;
-                    proxyContext?.NotifyFailure(proxyOptions, ex);
-                    throw;
+                    lastException = transformed;
+                    proxyContext?.NotifyFailure(proxyOptions, transformed);
+                    throw transformed;
                 }
                 finally
                 {
@@ -379,7 +381,7 @@ namespace Moljave.Http
                         continue;
                     }
 
-                    var transformed = proxyOptions.Descriptor != null ? CreateProxyException(ex) : ex;
+                    var transformed = NormalizeProxyException(ex, proxyOptions);
                     lastException = transformed;
 
                     if (transformed is ProxyException proxyException)
@@ -403,7 +405,7 @@ namespace Moljave.Http
                     }
 
                     proxyContext?.NotifyFailure(proxyOptions, transformed);
-                    throw;
+                    throw transformed;
                 }
                 catch (Exception ex)
                 {
@@ -414,17 +416,19 @@ namespace Moljave.Http
                         continue;
                     }
 
-                    if (attempt < maxRetries && ShouldRetry(ex, proxyOptions))
+                    var transformed = NormalizeProxyException(ex, proxyOptions);
+
+                    if (attempt < maxRetries && ShouldRetry(transformed, proxyOptions))
                     {
-                        lastException = ex;
-                        proxyContext?.NotifyFailure(proxyOptions, ex);
+                        lastException = transformed;
+                        proxyContext?.NotifyFailure(proxyOptions, transformed);
                         await DelayForRetryAsync(attempt, retryDelay, cancellationToken).ConfigureAwait(false);
                         continue;
                     }
 
-                    lastException = ex;
-                    proxyContext?.NotifyFailure(proxyOptions, ex);
-                    throw;
+                    lastException = transformed;
+                    proxyContext?.NotifyFailure(proxyOptions, transformed);
+                    throw transformed;
                 }
             }
 
@@ -663,6 +667,50 @@ namespace Moljave.Http
         private static bool IsRetryableProxyError(ProxyException proxyException)
         {
             return proxyException != null && proxyException.Reason is ProxyErrorReason.ConnectionFailed or ProxyErrorReason.ProtocolError;
+        }
+
+        private static Exception NormalizeProxyException(Exception exception, MojaveProxyOptions proxyOptions)
+        {
+            if (exception == null || proxyOptions?.Descriptor == null || exception is ProxyException)
+            {
+                return exception;
+            }
+
+            switch (exception)
+            {
+                case HttpRequestException httpRequestException:
+                    return CreateProxyException(httpRequestException);
+                case AuthenticationException authenticationException:
+                    return new ProxyException(
+                        "Failed to establish a secure connection through the proxy.",
+                        ProxyErrorReason.ConnectionFailed,
+                        innerException: authenticationException);
+                case TimeoutException timeoutException:
+                    return new ProxyException(
+                        "The proxy did not respond within the allotted timeout.",
+                        ProxyErrorReason.ConnectionFailed,
+                        innerException: timeoutException);
+                case SocketException or IOException:
+                    return new ProxyException(
+                        "Failed to communicate with the proxy server.",
+                        ProxyErrorReason.ConnectionFailed,
+                        innerException: exception);
+                case WebException webException:
+                    {
+                        var statusCode = (webException.Response as HttpWebResponse)?.StatusCode;
+                        var reason = webException.Status == WebExceptionStatus.ProtocolError
+                            ? ProxyErrorReason.ProtocolError
+                            : ProxyErrorReason.ConnectionFailed;
+
+                        return new ProxyException(
+                            webException.Message,
+                            reason,
+                            statusCode,
+                            webException);
+                    }
+                default:
+                    return exception;
+            }
         }
 
         private static async Task DelayForRetryAsync(int attempt, TimeSpan baseDelay, CancellationToken cancellationToken)

--- a/MoljaveHttpClient.cs
+++ b/MoljaveHttpClient.cs
@@ -1,6 +1,8 @@
 using System;
+using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -8,17 +10,28 @@ namespace Moljave.Http
 {
     public sealed class MojaveHttpClient : IDisposable
     {
+        private static readonly Version s_defaultRequestVersion = HttpVersion.Version11;
+
         private readonly MojaveHttpClientOptions _options;
         private readonly HttpMessageInvoker _invoker;
         private readonly MojaveCookieManager _cookieManager;
         private readonly object _fingerprintLock = new();
         private readonly object _proxyLock = new();
+        private readonly HttpRequestMessage _defaultRequest = new();
+        private readonly HttpRequestHeaders _defaultRequestHeaders;
+
         private Func<JA3Fingerprint> _fingerprintFactory;
         private JA3Fingerprint _currentFingerprint;
+
         private Func<MojaveProxyOptions> _defaultProxyResolver;
         private Func<MojaveProxyOptions> _overrideProxyResolver;
         private MojaveProxyOptions _staticProxyOptions;
         private bool _proxyEnabled = true;
+
+        private Uri _baseAddress;
+        private Version _defaultRequestVersion = s_defaultRequestVersion;
+        private HttpVersionPolicy _defaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+        private long _maxResponseContentBufferSize = int.MaxValue;
         private bool _disposed;
 
         public MojaveHttpClient()
@@ -59,6 +72,8 @@ namespace Moljave.Http
             _cookieManager = _options.CookieManager ?? new MojaveCookieManager();
             _options.CookieManager = _cookieManager;
 
+            _defaultRequestHeaders = _defaultRequest.Headers;
+
             InitializeFingerprint(_options.FingerprintProvider);
             _options.FingerprintProvider = ResolveFingerprint;
 
@@ -66,6 +81,62 @@ namespace Moljave.Http
             _options.ProxyResolver = ResolveProxy;
 
             _invoker = new HttpMessageInvoker(_options.BuildHandlerPipeline(), disposeHandler: true);
+        }
+
+        public Uri BaseAddress
+        {
+            get => Volatile.Read(ref _baseAddress);
+            set
+            {
+                if (value != null && !value.IsAbsoluteUri)
+                {
+                    throw new ArgumentException("BaseAddress must be an absolute URI.", nameof(value));
+                }
+
+                Volatile.Write(ref _baseAddress, value);
+            }
+        }
+
+        public HttpRequestHeaders DefaultRequestHeaders => _defaultRequestHeaders;
+
+        public Version DefaultRequestVersion
+        {
+            get => Volatile.Read(ref _defaultRequestVersion);
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                Volatile.Write(ref _defaultRequestVersion, value);
+            }
+        }
+
+        public HttpVersionPolicy DefaultVersionPolicy
+        {
+            get => Volatile.Read(ref _defaultVersionPolicy);
+            set => Volatile.Write(ref _defaultVersionPolicy, value);
+        }
+
+        public long MaxResponseContentBufferSize
+        {
+            get => Volatile.Read(ref _maxResponseContentBufferSize);
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "The buffer size cannot be negative.");
+                }
+
+                Volatile.Write(ref _maxResponseContentBufferSize, value);
+            }
+        }
+
+        public TimeSpan Timeout
+        {
+            get => _options.DefaultTimeout;
+            set => _options.DefaultTimeout = value;
         }
 
         public bool AllowAutoRedirect
@@ -80,10 +151,22 @@ namespace Moljave.Http
             set => _options.MaxAutomaticRedirections = value;
         }
 
-        public TimeSpan DefaultTimeout
+        public int MaxConnectionRetries
         {
-            get => _options.DefaultTimeout;
-            set => _options.DefaultTimeout = value;
+            get => _options.MaxConnectionRetries;
+            set => _options.MaxConnectionRetries = value;
+        }
+
+        public TimeSpan ConnectionRetryDelay
+        {
+            get => _options.ConnectionRetryDelay;
+            set => _options.ConnectionRetryDelay = value;
+        }
+
+        public int MaxConnectionsPerHost
+        {
+            get => _options.MaxConnectionsPerHost;
+            set => _options.MaxConnectionsPerHost = value;
         }
 
         public CookieContainer CookieContainer
@@ -93,6 +176,172 @@ namespace Moljave.Http
         }
 
         public MojaveCookieManager CookieManager => _cookieManager;
+
+        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
+            => SendAsync(request, HttpCompletionOption.ResponseContentRead, cancellationToken);
+
+        public async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            HttpCompletionOption completionOption,
+            CancellationToken cancellationToken = default)
+        {
+            if (completionOption is not HttpCompletionOption.ResponseContentRead and not HttpCompletionOption.ResponseHeadersRead)
+            {
+                throw new ArgumentOutOfRangeException(nameof(completionOption));
+            }
+
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(MojaveHttpClient));
+            }
+
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            PrepareRequest(request);
+            ApplyDefaultRequestOptions(request);
+
+            HttpResponseMessage response = await _invoker.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+            if (completionOption == HttpCompletionOption.ResponseContentRead)
+            {
+                await EnsureContentBufferedAsync(response, cancellationToken).ConfigureAwait(false);
+            }
+
+            return response;
+        }
+
+        public Task<HttpResponseMessage> GetAsync(string requestUri)
+            => GetAsync(CreateUri(requestUri), HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+
+        public Task<HttpResponseMessage> GetAsync(string requestUri, HttpCompletionOption completionOption)
+            => GetAsync(CreateUri(requestUri), completionOption, CancellationToken.None);
+
+        public Task<HttpResponseMessage> GetAsync(string requestUri, CancellationToken cancellationToken)
+            => GetAsync(CreateUri(requestUri), HttpCompletionOption.ResponseContentRead, cancellationToken);
+
+        public Task<HttpResponseMessage> GetAsync(string requestUri, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+            => GetAsync(CreateUri(requestUri), completionOption, cancellationToken);
+
+        public Task<HttpResponseMessage> GetAsync(Uri requestUri)
+            => GetAsync(requestUri, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+
+        public Task<HttpResponseMessage> GetAsync(Uri requestUri, HttpCompletionOption completionOption)
+            => GetAsync(requestUri, completionOption, CancellationToken.None);
+
+        public async Task<HttpResponseMessage> GetAsync(Uri requestUri, CancellationToken cancellationToken)
+            => await GetAsync(requestUri, HttpCompletionOption.ResponseContentRead, cancellationToken).ConfigureAwait(false);
+
+        public async Task<HttpResponseMessage> GetAsync(Uri requestUri, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        {
+            using var request = CreateRequestMessage(HttpMethod.Get, requestUri);
+            return await SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<string> GetStringAsync(string requestUri)
+            => await GetStringAsync(CreateUri(requestUri), CancellationToken.None).ConfigureAwait(false);
+
+        public async Task<string> GetStringAsync(string requestUri, CancellationToken cancellationToken)
+            => await GetStringAsync(CreateUri(requestUri), cancellationToken).ConfigureAwait(false);
+
+        public async Task<string> GetStringAsync(Uri requestUri)
+            => await GetStringAsync(requestUri, CancellationToken.None).ConfigureAwait(false);
+
+        public async Task<string> GetStringAsync(Uri requestUri, CancellationToken cancellationToken)
+        {
+            using var response = await GetAsync(requestUri, HttpCompletionOption.ResponseContentRead, cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        }
+
+        public async Task<byte[]> GetByteArrayAsync(string requestUri)
+            => await GetByteArrayAsync(CreateUri(requestUri), CancellationToken.None).ConfigureAwait(false);
+
+        public async Task<byte[]> GetByteArrayAsync(string requestUri, CancellationToken cancellationToken)
+            => await GetByteArrayAsync(CreateUri(requestUri), cancellationToken).ConfigureAwait(false);
+
+        public async Task<byte[]> GetByteArrayAsync(Uri requestUri)
+            => await GetByteArrayAsync(requestUri, CancellationToken.None).ConfigureAwait(false);
+
+        public async Task<byte[]> GetByteArrayAsync(Uri requestUri, CancellationToken cancellationToken)
+        {
+            using var response = await GetAsync(requestUri, HttpCompletionOption.ResponseContentRead, cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+        }
+
+        public async Task<Stream> GetStreamAsync(string requestUri)
+            => await GetStreamAsync(CreateUri(requestUri), CancellationToken.None).ConfigureAwait(false);
+
+        public async Task<Stream> GetStreamAsync(string requestUri, CancellationToken cancellationToken)
+            => await GetStreamAsync(CreateUri(requestUri), cancellationToken).ConfigureAwait(false);
+
+        public async Task<Stream> GetStreamAsync(Uri requestUri)
+            => await GetStreamAsync(requestUri, CancellationToken.None).ConfigureAwait(false);
+
+        public async Task<Stream> GetStreamAsync(Uri requestUri, CancellationToken cancellationToken)
+        {
+            var response = await GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                response.EnsureSuccessStatusCode();
+                return await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                response.Dispose();
+                throw;
+            }
+        }
+
+        public Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content)
+            => PostAsync(CreateUri(requestUri), content, CancellationToken.None);
+
+        public Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content, CancellationToken cancellationToken)
+            => PostAsync(CreateUri(requestUri), content, cancellationToken);
+
+        public Task<HttpResponseMessage> PostAsync(Uri requestUri, HttpContent content)
+            => PostAsync(requestUri, content, CancellationToken.None);
+
+        public async Task<HttpResponseMessage> PostAsync(Uri requestUri, HttpContent content, CancellationToken cancellationToken)
+        {
+            using var request = CreateRequestMessage(HttpMethod.Post, requestUri);
+            request.Content = content;
+            return await SendAsync(request, HttpCompletionOption.ResponseContentRead, cancellationToken).ConfigureAwait(false);
+        }
+
+        public Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent content)
+            => PutAsync(CreateUri(requestUri), content, CancellationToken.None);
+
+        public Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent content, CancellationToken cancellationToken)
+            => PutAsync(CreateUri(requestUri), content, cancellationToken);
+
+        public Task<HttpResponseMessage> PutAsync(Uri requestUri, HttpContent content)
+            => PutAsync(requestUri, content, CancellationToken.None);
+
+        public async Task<HttpResponseMessage> PutAsync(Uri requestUri, HttpContent content, CancellationToken cancellationToken)
+        {
+            using var request = CreateRequestMessage(HttpMethod.Put, requestUri);
+            request.Content = content;
+            return await SendAsync(request, HttpCompletionOption.ResponseContentRead, cancellationToken).ConfigureAwait(false);
+        }
+
+        public Task<HttpResponseMessage> DeleteAsync(string requestUri)
+            => DeleteAsync(CreateUri(requestUri), CancellationToken.None);
+
+        public Task<HttpResponseMessage> DeleteAsync(string requestUri, CancellationToken cancellationToken)
+            => DeleteAsync(CreateUri(requestUri), cancellationToken);
+
+        public Task<HttpResponseMessage> DeleteAsync(Uri requestUri)
+            => DeleteAsync(requestUri, CancellationToken.None);
+
+        public async Task<HttpResponseMessage> DeleteAsync(Uri requestUri, CancellationToken cancellationToken)
+        {
+            using var request = CreateRequestMessage(HttpMethod.Delete, requestUri);
+            return await SendAsync(request, HttpCompletionOption.ResponseContentRead, cancellationToken).ConfigureAwait(false);
+        }
 
         public void RotateFingerprint()
         {
@@ -232,32 +481,121 @@ namespace Moljave.Http
 
             _disposed = true;
             _invoker.Dispose();
+            _defaultRequest.Dispose();
         }
 
-        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
-            => SendAsync(request, _options.DefaultTimeout, cancellationToken);
-
-        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, TimeSpan timeout, CancellationToken cancellationToken = default)
+        private void PrepareRequest(HttpRequestMessage request)
         {
-            if (_disposed)
+            if (request.RequestUri == null)
             {
-                throw new ObjectDisposedException(nameof(MojaveHttpClient));
+                var baseAddress = BaseAddress;
+                if (baseAddress == null)
+                {
+                    throw new InvalidOperationException("The request URI must be absolute or BaseAddress must be set.");
+                }
+
+                request.RequestUri = baseAddress;
+            }
+            else if (!request.RequestUri.IsAbsoluteUri)
+            {
+                var baseAddress = BaseAddress;
+                if (baseAddress == null)
+                {
+                    throw new InvalidOperationException("The request URI must be absolute or BaseAddress must be set.");
+                }
+
+                request.RequestUri = new Uri(baseAddress, request.RequestUri);
             }
 
-            if (request == null)
+            if (request.Version == null || request.Version == s_defaultRequestVersion)
             {
-                throw new ArgumentNullException(nameof(request));
+                request.Version = DefaultRequestVersion;
             }
 
+            if (request.VersionPolicy == HttpVersionPolicy.RequestVersionOrLower)
+            {
+                request.VersionPolicy = DefaultVersionPolicy;
+            }
+
+            ApplyDefaultHeaders(request);
+        }
+
+        private void ApplyDefaultHeaders(HttpRequestMessage request)
+        {
+            if (_defaultRequestHeaders == null)
+            {
+                return;
+            }
+
+            foreach (var header in _defaultRequestHeaders)
+            {
+                if (!request.Headers.TryAddWithoutValidation(header.Key, header.Value))
+                {
+                    request.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+            }
+        }
+
+        private void ApplyDefaultRequestOptions(HttpRequestMessage request)
+        {
             request.ConfigureMojaveOptions(options =>
             {
-                if (!options.Timeout.HasValue)
-                {
-                    options.Timeout = timeout;
-                }
+                options.Timeout ??= _options.DefaultTimeout;
+                options.AllowAutoRedirect ??= _options.AllowAutoRedirect;
+                options.MaxAutomaticRedirections ??= _options.MaxAutomaticRedirections;
+                options.CookieManager ??= _options.CookieManager;
+                options.MaxConnectionRetries ??= _options.MaxConnectionRetries;
+                options.RetryDelay ??= _options.ConnectionRetryDelay;
             });
+        }
 
-            return _invoker.SendAsync(request, cancellationToken);
+        private async Task EnsureContentBufferedAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+        {
+            if (response?.Content == null)
+            {
+                return;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var maxBufferSize = Volatile.Read(ref _maxResponseContentBufferSize);
+            if (maxBufferSize <= 0)
+            {
+                await response.Content.LoadIntoBufferAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                await response.Content.LoadIntoBufferAsync(maxBufferSize).ConfigureAwait(false);
+            }
+        }
+
+        private static Uri CreateUri(string requestUri)
+        {
+            if (requestUri == null)
+            {
+                throw new ArgumentNullException(nameof(requestUri));
+            }
+
+            return new Uri(requestUri, UriKind.RelativeOrAbsolute);
+        }
+
+        private HttpRequestMessage CreateRequestMessage(HttpMethod method, Uri requestUri)
+        {
+            if (method == null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
+            if (requestUri == null)
+            {
+                throw new ArgumentNullException(nameof(requestUri));
+            }
+
+            return new HttpRequestMessage(method, requestUri)
+            {
+                Version = DefaultRequestVersion,
+                VersionPolicy = DefaultVersionPolicy
+            };
         }
 
         private void InitializeProxy(Func<MojaveProxyOptions> proxyResolver)

--- a/PlatformRequirements.cs
+++ b/PlatformRequirements.cs
@@ -12,6 +12,23 @@ namespace Moljave.Http
             {
                 throw new PlatformNotSupportedException("MojaveHttpClient requires Windows 10 version 2004 (build 19041) or newer.");
             }
+
+            var frameworkDescription = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
+            if (string.IsNullOrWhiteSpace(frameworkDescription))
+            {
+                throw new PlatformNotSupportedException("Unable to determine the runtime version. MojaveHttpClient requires .NET 9.0.");
+            }
+
+            if (!frameworkDescription.Contains(".NET", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new PlatformNotSupportedException($"Unsupported runtime '{frameworkDescription}'. MojaveHttpClient requires .NET 9.0 on Windows.");
+            }
+
+            var runtimeVersion = Environment.Version;
+            if (runtimeVersion == null || runtimeVersion.Major < 9)
+            {
+                throw new PlatformNotSupportedException($"Detected runtime version '{frameworkDescription}'. MojaveHttpClient requires .NET 9.0 or later on Windows.");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- rebuild MojaveHttpClient to mirror HttpClient semantics while supporting Chrome JA3 defaults, runtime proxy toggles, and request helpers
- make MojaveHttpClientOptions thread-safe and raise the default TLS pool ceiling to 15,000 concurrent connections
- harden proxy error handling and enforce the Windows/.NET 9 runtime requirement during initialization

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68f21a5e161483328ee93ed33f00caac