### PR TITLE
Enhance proxy handling and runtime cookie management

### DIFF
--- a/MoljaveHttpClient.cs
+++ b/MoljaveHttpClient.cs
@@ -10,8 +10,6 @@ namespace Moljave.Http
 {
     public sealed class MojaveHttpClient : IDisposable
     {
-        private static readonly Version s_defaultRequestVersion = HttpVersion.Version11;
-
         private readonly MojaveHttpClientOptions _options;
         private readonly HttpMessageInvoker _invoker;
         private readonly MojaveCookieManager _cookieManager;
@@ -19,6 +17,7 @@ namespace Moljave.Http
         private readonly object _proxyLock = new();
         private readonly HttpRequestMessage _defaultRequest = new();
         private readonly HttpRequestHeaders _defaultRequestHeaders;
+        private readonly Version _http11Version = HttpVersion.Version11;
 
         private Func<JA3Fingerprint> _fingerprintFactory;
         private JA3Fingerprint _currentFingerprint;
@@ -29,7 +28,7 @@ namespace Moljave.Http
         private bool _proxyEnabled = true;
 
         private Uri _baseAddress;
-        private Version _defaultRequestVersion = s_defaultRequestVersion;
+        private Version _defaultRequestVersion;
         private HttpVersionPolicy _defaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
         private long _maxResponseContentBufferSize = int.MaxValue;
         private bool _disposed;
@@ -73,6 +72,7 @@ namespace Moljave.Http
             _options.CookieManager = _cookieManager;
 
             _defaultRequestHeaders = _defaultRequest.Headers;
+            _defaultRequestVersion = _http11Version;
 
             InitializeFingerprint(_options.FingerprintProvider);
             _options.FingerprintProvider = ResolveFingerprint;
@@ -176,6 +176,21 @@ namespace Moljave.Http
         }
 
         public MojaveCookieManager CookieManager => _cookieManager;
+
+        public void SetCookie(Uri uri, Cookie cookie) => _cookieManager.SetCookie(uri, cookie);
+
+        public void SetCookie(
+            string domain,
+            string name,
+            string value,
+            string path = "/",
+            DateTime? expires = null,
+            bool? secure = null,
+            bool? httpOnly = null) =>
+            _cookieManager.SetCookie(domain, name, value, path, expires, secure, httpOnly);
+
+        public void RemoveCookie(string domain, string name, string path = "/") =>
+            _cookieManager.RemoveCookie(domain, name, path);
 
         public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
             => SendAsync(request, HttpCompletionOption.ResponseContentRead, cancellationToken);
@@ -347,7 +362,7 @@ namespace Moljave.Http
         {
             lock (_fingerprintLock)
             {
-                _currentFingerprint = (_fingerprintFactory ?? DefaultFingerprintFactory)();
+                _currentFingerprint = (_fingerprintFactory ?? CreateDefaultFingerprint)();
             }
         }
 
@@ -507,7 +522,7 @@ namespace Moljave.Http
                 request.RequestUri = new Uri(baseAddress, request.RequestUri);
             }
 
-            if (request.Version == null || request.Version == s_defaultRequestVersion)
+            if (request.Version == null || IsDefaultHttp11(request.Version))
             {
                 request.Version = DefaultRequestVersion;
             }
@@ -661,7 +676,7 @@ namespace Moljave.Http
         {
             lock (_fingerprintLock)
             {
-                _fingerprintFactory = fingerprintProvider ?? DefaultFingerprintFactory;
+                _fingerprintFactory = fingerprintProvider ?? CreateDefaultFingerprint;
                 _currentFingerprint = _fingerprintFactory();
             }
         }
@@ -670,7 +685,7 @@ namespace Moljave.Http
         {
             lock (_fingerprintLock)
             {
-                _currentFingerprint ??= (_fingerprintFactory ?? DefaultFingerprintFactory)();
+                _currentFingerprint ??= (_fingerprintFactory ?? CreateDefaultFingerprint)();
                 return _currentFingerprint;
             }
         }
@@ -682,7 +697,27 @@ namespace Moljave.Http
             return options;
         }
 
-        private static JA3Fingerprint DefaultFingerprintFactory()
+        private bool IsDefaultHttp11(Version version)
+        {
+            if (version == null)
+            {
+                return true;
+            }
+
+            if (version.Major != 1 || version.Minor != 1)
+            {
+                return false;
+            }
+
+            var build = version.Build;
+            var revision = version.Revision;
+
+            bool IsUnset(int value) => value < 0;
+
+            return (IsUnset(build) || build == 0) && (IsUnset(revision) || revision == 0);
+        }
+
+        private JA3Fingerprint CreateDefaultFingerprint()
             => JA3FingerprintFactory.GetFingerprint(BrowserJa3Profile.Chrome);
     }
 }

--- a/ProxyOptions.cs
+++ b/ProxyOptions.cs
@@ -33,9 +33,9 @@ namespace Moljave.Http
         {
             var uriBuilder = new UriBuilder
             {
-                Scheme = Scheme == ProxyScheme.Https ? Uri.UriSchemeHttps : Uri.UriSchemeHttp,
+                Scheme = GetSchemeString(Scheme, ResolveHostnamesRemotely),
                 Host = Host,
-                Port = Port
+                Port = Port > 0 ? Port : GetDefaultPort(Scheme)
             };
 
             var proxy = new WebProxy(uriBuilder.Uri);
@@ -84,12 +84,19 @@ namespace Moljave.Http
             }
 
             var address = proxy.Address;
-            var scheme = address.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase)
-                ? ProxyScheme.Https
-                : ProxyScheme.Http;
+            if (string.IsNullOrWhiteSpace(address.Host))
+            {
+                return NoProxy;
+            }
+            var scheme = ParseScheme(address?.Scheme, out var resolveRemotely);
+            var port = address?.Port ?? -1;
+            if (port <= 0)
+            {
+                port = GetDefaultPort(scheme);
+            }
 
             var credentials = ExtractCredentials(proxy, address);
-            var descriptor = new ProxyDescriptor(scheme, address.Host, address.Port, credentials);
+            var descriptor = new ProxyDescriptor(scheme, address.Host, port, credentials, resolveRemotely);
             return new MojaveProxyOptions(descriptor);
         }
 
@@ -101,12 +108,19 @@ namespace Moljave.Http
             }
 
             var address = proxy.Address;
-            var scheme = address.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase)
-                ? ProxyScheme.Https
-                : ProxyScheme.Http;
+            if (string.IsNullOrWhiteSpace(address.Host))
+            {
+                return NoProxy;
+            }
+            var scheme = ParseScheme(address?.Scheme, out var resolveRemotely);
+            var port = address?.Port ?? -1;
+            if (port <= 0)
+            {
+                port = GetDefaultPort(scheme);
+            }
 
             var credentials = ExtractCredentials(proxy, address);
-            var descriptor = new ProxyDescriptor(scheme, address.Host, address.Port, credentials);
+            var descriptor = new ProxyDescriptor(scheme, address.Host, port, credentials, resolveRemotely);
             return new MojaveProxyOptions(descriptor, rotationListener);
         }
 
@@ -155,6 +169,59 @@ namespace Moljave.Http
             }
 
             return null;
+        }
+
+        private static ProxyScheme ParseScheme(string scheme, out bool resolveRemotely)
+        {
+            resolveRemotely = false;
+
+            if (string.IsNullOrWhiteSpace(scheme))
+            {
+                return ProxyScheme.Http;
+            }
+
+            switch (scheme.ToLowerInvariant())
+            {
+                case "https":
+                    return ProxyScheme.Https;
+                case "socks":
+                case "socks5":
+                    return ProxyScheme.Socks5;
+                case "socks5h":
+                    resolveRemotely = true;
+                    return ProxyScheme.Socks5;
+                case "socks4":
+                    return ProxyScheme.Socks4;
+                case "socks4a":
+                    resolveRemotely = true;
+                    return ProxyScheme.Socks4a;
+                default:
+                    return ProxyScheme.Http;
+            }
+        }
+
+        private static string GetSchemeString(ProxyScheme scheme, bool resolveRemotely)
+        {
+            return scheme switch
+            {
+                ProxyScheme.Https => Uri.UriSchemeHttps,
+                ProxyScheme.Socks4 when resolveRemotely => "socks4a",
+                ProxyScheme.Socks4 => "socks4",
+                ProxyScheme.Socks4a => "socks4a",
+                ProxyScheme.Socks5 when resolveRemotely => "socks5h",
+                ProxyScheme.Socks5 => "socks5",
+                _ => Uri.UriSchemeHttp
+            };
+        }
+
+        private static int GetDefaultPort(ProxyScheme scheme)
+        {
+            return scheme switch
+            {
+                ProxyScheme.Https => 443,
+                ProxyScheme.Socks4 or ProxyScheme.Socks4a or ProxyScheme.Socks5 => 1080,
+                _ => 80
+            };
         }
     }
 }


### PR DESCRIPTION
## Summary
- add runtime cookie management helpers and remove static version state from `MojaveHttpClient`
- ensure default HTTP/1.1 detection respects custom versions while reusing instance defaults
- expand `WebProxy` conversion to support SOCKS schemes, remote DNS flags, and default ports

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68f222cdfd4883328c681feaafbf22d1