### PR TITLE
Fix HttpVersionPolicy volatility and import SslProtocols

### DIFF
--- a/MojaveHttpClientOptions.cs
+++ b/MojaveHttpClientOptions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Security;
+using System.Security.Authentication;
 using System.Threading;
 
 namespace Moljave.Http

--- a/MoljaveHttpClient.cs
+++ b/MoljaveHttpClient.cs
@@ -30,7 +30,7 @@ namespace Moljave.Http
 
         private Uri _baseAddress;
         private Version _defaultRequestVersion = s_defaultRequestVersion;
-        private HttpVersionPolicy _defaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+        private int _defaultVersionPolicy = (int)HttpVersionPolicy.RequestVersionOrHigher;
         private long _maxResponseContentBufferSize = int.MaxValue;
         private bool _disposed;
 
@@ -115,8 +115,8 @@ namespace Moljave.Http
 
         public HttpVersionPolicy DefaultVersionPolicy
         {
-            get => Volatile.Read(ref _defaultVersionPolicy);
-            set => Volatile.Write(ref _defaultVersionPolicy, value);
+            get => (HttpVersionPolicy)Volatile.Read(ref _defaultVersionPolicy);
+            set => Volatile.Write(ref _defaultVersionPolicy, (int)value);
         }
 
         public long MaxResponseContentBufferSize


### PR DESCRIPTION
## Summary
- adjust MojaveHttpClient to store the default version policy as an integer so Volatile access works with the enum value
- import System.Security.Authentication in MojaveHttpClientOptions so SslProtocols resolves

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f21dae07ec8332b67ca45c0e4800bc