### PR TITLE
Isolate TLS pool per cookie manager to preserve cookies

### DIFF
--- a/MojaveHttpMessageHandler.cs
+++ b/MojaveHttpMessageHandler.cs
@@ -81,7 +81,7 @@ namespace Moljave.Http
 
                 HttpResponseMessage response = ShouldUseHttp2(currentRequest)
                     ? await SendHttp2Async(currentRequest, uri, effectiveTimeout, fingerprint, tlsSettings, proxyContext, maxRetries, retryDelay, cancellationToken).ConfigureAwait(false)
-                    : await SendHttp11Async(currentRequest, uri, useTls, effectiveTimeout, fingerprint, tlsSettings, proxyContext, maxRetries, retryDelay, cancellationToken).ConfigureAwait(false);
+                    : await SendHttp11Async(currentRequest, uri, useTls, effectiveTimeout, fingerprint, tlsSettings, proxyContext, cookieManager, maxRetries, retryDelay, cancellationToken).ConfigureAwait(false);
 
                 if (cookieManager != null && response.Headers.TryGetValues("Set-Cookie", out var setCookieHeaders))
                 {
@@ -165,6 +165,7 @@ namespace Moljave.Http
             JA3Fingerprint fingerprint,
             MojaveTlsSettings tlsSettings,
             ProxyRotationContext proxyContext,
+            MojaveCookieManager cookieManager,
             int maxRetries,
             TimeSpan retryDelay,
             CancellationToken cancellationToken)
@@ -199,6 +200,7 @@ namespace Moljave.Http
                         fingerprint,
                         tlsSettings,
                         proxyOptions.Descriptor,
+                        cookieManager,
                         _options.CertificateValidationCallback,
                         _options.MaxConnectionsPerHost,
                         waitToken).ConfigureAwait(false);

--- a/TlsConnectionPool.cs
+++ b/TlsConnectionPool.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Security;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -26,6 +27,7 @@ namespace Moljave.Http
             JA3Fingerprint fingerprint,
             MojaveTlsSettings tlsSettings,
             ProxyDescriptor proxyDescriptor,
+            object affinityKey,
             RemoteCertificateValidationCallback certificateValidationCallback,
             int maxConnections,
             CancellationToken cancellationToken)
@@ -37,13 +39,18 @@ namespace Moljave.Http
 
             maxConnections = Math.Max(1, maxConnections);
 
+            var affinityHash = affinityKey == null
+                ? 0
+                : RuntimeHelpers.GetHashCode(affinityKey);
+
             var key = new PoolKey(
                 host,
                 port,
                 useTls,
                 BuildFingerprintSignature(fingerprint),
                 BuildTlsSignature(tlsSettings),
-                BuildProxySignature(proxyDescriptor));
+                BuildProxySignature(proxyDescriptor),
+                affinityHash);
 
             var state = _states.GetOrAdd(key, _ => new PoolState());
             var semaphore = state.GetSemaphore(maxConnections);
@@ -163,7 +170,7 @@ namespace Moljave.Http
 
         internal readonly struct PoolKey : IEquatable<PoolKey>
         {
-            public PoolKey(string host, int port, bool useTls, string fingerprintSignature, string tlsSignature, string proxySignature)
+            public PoolKey(string host, int port, bool useTls, string fingerprintSignature, string tlsSignature, string proxySignature, int affinityHash)
             {
                 Host = host;
                 Port = port;
@@ -171,6 +178,7 @@ namespace Moljave.Http
                 FingerprintSignature = fingerprintSignature;
                 TlsSignature = tlsSignature;
                 ProxySignature = proxySignature;
+                AffinityHash = affinityHash;
             }
 
             public string Host { get; }
@@ -179,6 +187,7 @@ namespace Moljave.Http
             public string FingerprintSignature { get; }
             public string TlsSignature { get; }
             public string ProxySignature { get; }
+            public int AffinityHash { get; }
 
             public bool Equals(PoolKey other)
             {
@@ -187,7 +196,8 @@ namespace Moljave.Http
                     string.Equals(Host, other.Host, StringComparison.OrdinalIgnoreCase) &&
                     string.Equals(FingerprintSignature, other.FingerprintSignature, StringComparison.Ordinal) &&
                     string.Equals(TlsSignature, other.TlsSignature, StringComparison.Ordinal) &&
-                    string.Equals(ProxySignature, other.ProxySignature, StringComparison.Ordinal);
+                    string.Equals(ProxySignature, other.ProxySignature, StringComparison.Ordinal) &&
+                    AffinityHash == other.AffinityHash;
             }
 
             public override bool Equals(object obj)
@@ -204,6 +214,7 @@ namespace Moljave.Http
                 hash.Add(FingerprintSignature, StringComparer.Ordinal);
                 hash.Add(TlsSignature, StringComparer.Ordinal);
                 hash.Add(ProxySignature, StringComparer.Ordinal);
+                hash.Add(AffinityHash);
                 return hash.ToHashCode();
             }
         }


### PR DESCRIPTION
## Summary
- include the request's cookie manager when renting a TLS client so direct connections are not reused across independent MojaveHttpClient instances
- add an affinity component to TLS connection pool keys to keep leases scoped to the owning cookie jar

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f9369b85c483328bdc96260d585567