### PR TITLE
Improve MojaveHttpClient response streaming and session isolation

### DIFF
--- a/HttpContentUtilities.cs
+++ b/HttpContentUtilities.cs
@@ -4,18 +4,22 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 
 namespace Moljave.Http
 {
     internal static class HttpContentUtilities
     {
         public static ByteArrayContent CreateContent(
-            byte[] body,
+            ReadOnlyMemory<byte> body,
             IList<KeyValuePair<string, string>> headers,
             out bool wasDecompressed)
         {
             var payload = DecodeBody(body, headers, out wasDecompressed);
-            var content = new ByteArrayContent(payload);
+            var array = payload.Array ?? Array.Empty<byte>();
+            var offset = payload.Offset;
+            var count = payload.Count;
+            var content = new ByteArrayContent(array, offset, count);
 
             if (headers != null)
             {
@@ -35,17 +39,17 @@ namespace Moljave.Http
                 }
             }
 
-            content.Headers.ContentLength = payload.LongLength;
+            content.Headers.ContentLength = count;
             return content;
         }
 
-        private static byte[] DecodeBody(byte[] body, IList<KeyValuePair<string, string>> headers, out bool wasDecompressed)
+        private static ArraySegment<byte> DecodeBody(ReadOnlyMemory<byte> body, IList<KeyValuePair<string, string>> headers, out bool wasDecompressed)
         {
             wasDecompressed = false;
 
-            if (body == null || body.Length == 0 || headers == null || headers.Count == 0)
+            if (body.IsEmpty || headers == null || headers.Count == 0)
             {
-                return body ?? Array.Empty<byte>();
+                return GetSegment(body);
             }
 
             var encodingHeader = headers.FirstOrDefault(h =>
@@ -53,7 +57,7 @@ namespace Moljave.Http
 
             if (string.IsNullOrEmpty(encodingHeader.Key))
             {
-                return body;
+                return GetSegment(body);
             }
 
             try
@@ -61,19 +65,19 @@ namespace Moljave.Http
                 if (encodingHeader.Value.Contains("gzip", StringComparison.OrdinalIgnoreCase))
                 {
                     wasDecompressed = true;
-                    return Decompress(body, stream => new GZipStream(stream, CompressionMode.Decompress));
+                    return CreateSegment(Decompress(body, stream => new GZipStream(stream, CompressionMode.Decompress)));
                 }
 
                 if (encodingHeader.Value.Contains("deflate", StringComparison.OrdinalIgnoreCase))
                 {
                     wasDecompressed = true;
-                    return Decompress(body, stream => new DeflateStream(stream, CompressionMode.Decompress));
+                    return CreateSegment(Decompress(body, stream => new DeflateStream(stream, CompressionMode.Decompress)));
                 }
 
                 if (encodingHeader.Value.Contains("br", StringComparison.OrdinalIgnoreCase))
                 {
                     wasDecompressed = true;
-                    return Decompress(body, stream => new BrotliStream(stream, CompressionMode.Decompress));
+                    return CreateSegment(Decompress(body, stream => new BrotliStream(stream, CompressionMode.Decompress)));
                 }
             }
             catch
@@ -81,17 +85,32 @@ namespace Moljave.Http
                 wasDecompressed = false;
             }
 
-            return body;
+            return GetSegment(body);
         }
 
-        private static byte[] Decompress(byte[] body, Func<Stream, Stream> factory)
+        private static byte[] Decompress(ReadOnlyMemory<byte> body, Func<Stream, Stream> factory)
         {
-            using var input = new MemoryStream(body);
+            var segment = GetSegment(body);
+            using var input = new MemoryStream(segment.Array, segment.Offset, segment.Count, writable: false);
             using var decompressor = factory(input);
             using var output = new MemoryStream();
             decompressor.CopyTo(output);
             return output.ToArray();
         }
+
+        private static ArraySegment<byte> GetSegment(ReadOnlyMemory<byte> body)
+        {
+            if (MemoryMarshal.TryGetArray(body, out ArraySegment<byte> segment))
+            {
+                return segment;
+            }
+
+            var copy = body.ToArray();
+            return new ArraySegment<byte>(copy, 0, copy.Length);
+        }
+
+        private static ArraySegment<byte> CreateSegment(byte[] array)
+            => array == null ? new ArraySegment<byte>(Array.Empty<byte>()) : new ArraySegment<byte>(array, 0, array.Length);
     }
 }
 

--- a/HttpRequestStringifier.cs
+++ b/HttpRequestStringifier.cs
@@ -6,12 +6,13 @@ using System.Net.Http;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using System.Runtime.InteropServices;
 
 namespace Moljave.Http
 {
     public static class HttpRequestStringifier
     {
-        public static async Task<byte[]> Stringify(HttpRequestMessage request)
+        public static async Task<HttpRequestPayload> Stringify(HttpRequestMessage request)
         {
             if (request == null)
             {
@@ -115,15 +116,21 @@ namespace Moljave.Http
             WriteCrlf();
 
             var headers = writer.WrittenMemory;
-            if (contentBytes.Length == 0)
+            if (!MemoryMarshal.TryGetArray(headers, out ArraySegment<byte> headerSegment))
             {
-                return headers.ToArray();
+                var headerCopy = headers.ToArray();
+                headerSegment = new ArraySegment<byte>(headerCopy, 0, headerCopy.Length);
             }
 
-            var result = new byte[headers.Length + contentBytes.Length];
-            headers.Span.CopyTo(result);
-            Buffer.BlockCopy(contentBytes, 0, result, headers.Length, contentBytes.Length);
-            return result;
+            if (contentBytes.Length == 0)
+            {
+                return new HttpRequestPayload(headerSegment.Array, headerSegment.Offset, headerSegment.Count);
+            }
+
+            var buffer = new byte[headerSegment.Count + contentBytes.Length];
+            Buffer.BlockCopy(headerSegment.Array, headerSegment.Offset, buffer, 0, headerSegment.Count);
+            Buffer.BlockCopy(contentBytes, 0, buffer, headerSegment.Count, contentBytes.Length);
+            return new HttpRequestPayload(buffer, 0, buffer.Length);
         }
 
         public static async Task<HttpRequestMessage> CloneWithRedirectAsync(
@@ -184,5 +191,31 @@ namespace Moljave.Http
             var value = versionPolicyProperty.GetValue(source);
             versionPolicyProperty.SetValue(destination, value);
         }
+    }
+
+    public readonly struct HttpRequestPayload
+    {
+        private readonly byte[] _buffer;
+        private readonly int _offset;
+        private readonly int _count;
+
+        public HttpRequestPayload(byte[] buffer, int offset, int count)
+        {
+            _buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
+            if (offset < 0 || count < 0 || buffer.Length - offset < count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            _offset = offset;
+            _count = count;
+        }
+
+        public bool IsEmpty => _buffer == null || _count == 0;
+
+        public int Length => _count;
+
+        public ReadOnlyMemory<byte> AsMemory()
+            => _buffer == null ? ReadOnlyMemory<byte>.Empty : new ReadOnlyMemory<byte>(_buffer, _offset, _count);
     }
 }

--- a/HttpResponseParser.cs
+++ b/HttpResponseParser.cs
@@ -3,29 +3,19 @@ using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Moljave.Http
 {
     public static class HttpResponseParser
     {
-        public static HttpResponseMessage Parse(byte[] responseBytes)
+        public static HttpResponseMessage Parse(ReadOnlySpan<byte> headerSpan, ReadOnlyMemory<byte> bodyMemory)
         {
-            if (responseBytes == null || responseBytes.Length == 0)
+            if (headerSpan.IsEmpty)
             {
-                throw new ArgumentException("Response bytes cannot be null or empty.", nameof(responseBytes));
+                throw new ArgumentException("Response header cannot be empty.", nameof(headerSpan));
             }
-
-            var separator = FindHeaderBodySeparator(responseBytes);
-            if (separator < 0)
-            {
-                throw new InvalidOperationException("Failed to locate HTTP header terminator.");
-            }
-
-            var headerSpan = responseBytes.AsSpan(0, separator);
-            var bodyLength = responseBytes.Length - separator;
-            var bodyBytes = new byte[bodyLength];
-            Buffer.BlockCopy(responseBytes, separator, bodyBytes, 0, bodyLength);
 
             var statusLineEnd = headerSpan.IndexOf((byte)'\n');
             if (statusLineEnd < 0)
@@ -84,22 +74,8 @@ namespace Moljave.Http
                 }
             }
 
-            response.Content = HttpContentUtilities.CreateContent(bodyBytes, contentHeaders, out _);
+            response.Content = HttpContentUtilities.CreateContent(bodyMemory, contentHeaders, out _);
             return response;
-        }
-
-        private static int FindHeaderBodySeparator(byte[] responseBytes)
-        {
-            for (int i = 0; i < responseBytes.Length - 3; i++)
-            {
-                if (responseBytes[i] == 13 && responseBytes[i + 1] == 10 &&
-                    responseBytes[i + 2] == 13 && responseBytes[i + 3] == 10)
-                {
-                    return i + 4;
-                }
-            }
-
-            return -1;
         }
 
         private static HttpResponseMessage ParseStatusLine(ReadOnlySpan<byte> statusLine)

--- a/MojaveHttpClientOptions.cs
+++ b/MojaveHttpClientOptions.cs
@@ -10,9 +10,6 @@ namespace Moljave.Http
 {
     public sealed class MojaveHttpClientOptions
     {
-        private const int MinimumSocketBufferSize = 1024;
-        private const int MinimumMaxConnectionsPerHost = 1;
-
         private long _defaultTimeoutTicks = TimeSpan.FromSeconds(30).Ticks;
         private int _allowAutoRedirect = 1;
         private int _maxAutomaticRedirections = 10;
@@ -122,93 +119,6 @@ namespace Moljave.Http
 
         public RemoteCertificateValidationCallback CertificateValidationCallback { get; set; }
             = (_, _, _, _) => true;
-
-        internal bool TryReduceSocketBufferSize(int observedValue)
-        {
-            while (true)
-            {
-                var current = Volatile.Read(ref _socketBufferSize);
-
-                if (current <= 0)
-                {
-                    return false;
-                }
-
-                if (observedValue > 0 && current < observedValue)
-                {
-                    return false;
-                }
-
-                int next;
-                if (current <= MinimumSocketBufferSize)
-                {
-                    next = 0;
-                }
-                else
-                {
-                    next = Math.Max(MinimumSocketBufferSize, current / 2);
-                    if (next == current)
-                    {
-                        next = MinimumSocketBufferSize;
-                    }
-                }
-
-                if (Interlocked.CompareExchange(ref _socketBufferSize, next, current) == current)
-                {
-                    return true;
-                }
-            }
-        }
-
-        internal bool TryReduceMaxConnectionsPerHost(int observedValue)
-        {
-            while (true)
-            {
-                var current = Volatile.Read(ref _maxConnectionsPerHost);
-
-                if (current <= MinimumMaxConnectionsPerHost)
-                {
-                    return false;
-                }
-
-                if (observedValue > 0 && current < observedValue)
-                {
-                    return false;
-                }
-
-                var next = Math.Max(MinimumMaxConnectionsPerHost, current / 2);
-                if (next == current)
-                {
-                    next = MinimumMaxConnectionsPerHost;
-                    if (next == current)
-                    {
-                        return false;
-                    }
-                }
-
-                if (Interlocked.CompareExchange(ref _maxConnectionsPerHost, next, current) == current)
-                {
-                    return true;
-                }
-            }
-        }
-
-        internal bool TryEnableForceCloseConnections()
-        {
-            while (true)
-            {
-                var current = Volatile.Read(ref _forceConnectionCloseAfterRequest);
-                if (current == 1)
-                {
-                    return false;
-                }
-
-                if (Interlocked.CompareExchange(ref _forceConnectionCloseAfterRequest, 1, current) == current)
-                {
-                    return true;
-                }
-            }
-        }
 
         internal HttpMessageHandler BuildHandlerPipeline()
         {

--- a/MojaveHttpMessageHandler.cs
+++ b/MojaveHttpMessageHandler.cs
@@ -56,6 +56,11 @@ namespace Moljave.Http
                 var socketBufferSize = requestOptions?.SocketBufferSize ?? _options.SocketBufferSize;
                 var maxConnectionsPerHost = requestOptions?.MaxConnectionsPerHost ?? _options.MaxConnectionsPerHost;
                 var affinityKey = forceCloseConnections ? null : requestOptions?.SessionAffinityKey ?? cookieManager;
+                if (!forceCloseConnections && affinityKey == null)
+                {
+                    throw new InvalidOperationException(
+                        "A non-null SessionAffinityKey is required when connection reuse is enabled. Configure MojaveRequestOptions.SessionAffinityKey or use a dedicated MojaveHttpClient per session.");
+                }
                 if (retryDelay < TimeSpan.Zero)
                 {
                     retryDelay = TimeSpan.Zero;
@@ -237,7 +242,8 @@ namespace Moljave.Http
             CancellationToken cancellationToken)
         {
             var requestWantsClose = RequestWantsConnectionClose(request);
-            byte[] cachedRequestPayload = null;
+            HttpRequestPayload cachedRequestPayload = default;
+            var hasCachedPayload = false;
             var requestPayloadDirty = true;
             var targetPort = uri.IsDefaultPort ? (useTls ? 443 : 80) : uri.Port;
 
@@ -279,15 +285,14 @@ namespace Moljave.Http
                         linkedCts.CancelAfter(timeout);
                     }
 
-                    if (requestPayloadDirty || cachedRequestPayload == null)
+                    if (requestPayloadDirty || !hasCachedPayload)
                     {
                         cachedRequestPayload = await HttpRequestStringifier.Stringify(request).ConfigureAwait(false);
+                        hasCachedPayload = true;
                         requestPayloadDirty = false;
                     }
 
-                    var requestPayload = cachedRequestPayload;
-                    var responseBytes = await lease.Client.SendRequestAsync(requestPayload, linkedCts.Token, useTls).ConfigureAwait(false);
-                    var response = HttpResponseParser.Parse(responseBytes);
+                    var response = await lease.Client.SendRequestAsync(cachedRequestPayload.AsMemory(), linkedCts.Token, useTls).ConfigureAwait(false);
                     response.RequestMessage = request;
 
                     var shouldClose = requestWantsClose || ResponseIndicatesConnectionClose(response);
@@ -321,41 +326,14 @@ namespace Moljave.Http
                 {
                     lease?.MarkUnusable();
 
-                    var exceptionToHandle = AugmentSocketResourceException(
-                        ex,
-                        uri,
-                        targetPort,
-                        useTls,
-                        fingerprint,
-                        tlsSettings,
-                        proxyOptions,
-                        cookieManager,
-                        affinityKey,
-                        socketBufferSize,
-                        maxConnectionsPerHost,
-                        forceCloseConnections);
-
-                    forceCloseConnections = _options.ForceCloseConnectionsAfterRequest || forceCloseConnections;
-                    if (forceCloseConnections)
+                    if (TlsPlatformSupport.TryDisableCipherSuitesPolicy(ex))
                     {
-                        affinityKey = null;
-                    }
-
-                    if (forceCloseConnections && request.Headers.ConnectionClose != true)
-                    {
-                        request.Headers.ConnectionClose = true;
-                        requestWantsClose = true;
-                        requestPayloadDirty = true;
-                    }
-
-                    if (TlsPlatformSupport.TryDisableCipherSuitesPolicy(exceptionToHandle))
-                    {
-                        lastException = exceptionToHandle;
+                        lastException = ex;
                         attempt--;
                         continue;
                     }
 
-                    var transformed = NormalizeProxyException(exceptionToHandle, proxyOptions);
+                    var transformed = NormalizeProxyException(ex, proxyOptions);
 
                     if (attempt < maxRetries && ShouldRetry(transformed, proxyOptions))
                     {
@@ -849,205 +827,6 @@ namespace Moljave.Http
             var delayMilliseconds = baseDelay.TotalMilliseconds * multiplier;
             var cappedMilliseconds = Math.Min(delayMilliseconds, 2000);
             return TimeSpan.FromMilliseconds(cappedMilliseconds);
-        }
-
-        private Exception AugmentSocketResourceException(
-            Exception exception,
-            Uri uri,
-            int port,
-            bool useTls,
-            JA3Fingerprint fingerprint,
-            MojaveTlsSettings tlsSettings,
-            MojaveProxyOptions proxyOptions,
-            MojaveCookieManager cookieManager,
-            object affinityKey,
-            int socketBufferSize,
-            int maxConnectionsPerHost,
-            bool forceCloseConnections)
-        {
-            var socketException = FindSocketException(exception);
-            if (socketException == null)
-            {
-                return exception;
-            }
-
-            switch (socketException.SocketErrorCode)
-            {
-                case SocketError.NoBufferSpaceAvailable:
-                    var noBufferSpaceException = CreateSocketResourceException(
-                        socketException,
-                        uri,
-                        port,
-                        useTls,
-                        fingerprint,
-                        tlsSettings,
-                        proxyOptions,
-                        cookieManager,
-                        affinityKey,
-                        forceCloseConnections,
-                        "The operating system ran out of socket buffer space while communicating with ",
-                        "Reduce concurrent connections or lower MojaveHttpClientOptions.SocketBufferSize to avoid exhausting kernel buffers.",
-                        socketBufferSize);
-                    var socketBufferReduced = _options.TryReduceSocketBufferSize(socketBufferSize);
-                    var maxConnectionsReduced = _options.TryReduceMaxConnectionsPerHost(maxConnectionsPerHost);
-                    var forceCloseActivated = _options.TryEnableForceCloseConnections();
-                    if (forceCloseActivated)
-                    {
-                        forceCloseConnections = true;
-                        affinityKey = null;
-                        if (uri != null)
-                        {
-                            TlsConnectionPool.Shared.ClearHostVariants(uri.Host, port, useTls);
-                        }
-                    }
-                    if (maxConnectionsReduced)
-                    {
-                        ReducePoolMaxConnections(
-                            uri,
-                            port,
-                            useTls,
-                            fingerprint,
-                            tlsSettings,
-                            proxyOptions,
-                            affinityKey,
-                            socketBufferSize,
-                            socketBufferReduced,
-                            forceCloseConnections);
-                    }
-                    return noBufferSpaceException;
-                case SocketError.AddressAlreadyInUse:
-                    var addressInUseException = CreateSocketResourceException(
-                        socketException,
-                        uri,
-                        port,
-                        useTls,
-                        fingerprint,
-                        tlsSettings,
-                        proxyOptions,
-                        cookieManager,
-                        affinityKey,
-                        forceCloseConnections,
-                        "The operating system refused to open a new socket because the local port range is exhausted while communicating with ",
-                        "Reduce concurrent connections or lower MojaveHttpClientOptions.MaxConnectionsPerHost to avoid running out of ephemeral ports.",
-                        socketBufferSize);
-                    var forceCloseEnabled = _options.TryEnableForceCloseConnections();
-                    if (forceCloseEnabled)
-                    {
-                        forceCloseConnections = true;
-                        affinityKey = null;
-                        if (uri != null)
-                        {
-                            TlsConnectionPool.Shared.ClearHostVariants(uri.Host, port, useTls);
-                        }
-                    }
-                    if (_options.TryReduceMaxConnectionsPerHost(maxConnectionsPerHost))
-                    {
-                        ReducePoolMaxConnections(
-                            uri,
-                            port,
-                            useTls,
-                            fingerprint,
-                            tlsSettings,
-                            proxyOptions,
-                            affinityKey,
-                            socketBufferSize,
-                            socketBufferReduced: false,
-                            forceCloseConnections);
-                    }
-                    return addressInUseException;
-                default:
-                    return exception;
-            }
-        }
-        private HttpRequestException CreateSocketResourceException(
-            SocketException socketException,
-            Uri uri,
-            int port,
-            bool useTls,
-            JA3Fingerprint fingerprint,
-            MojaveTlsSettings tlsSettings,
-            MojaveProxyOptions proxyOptions,
-            MojaveCookieManager cookieManager,
-            object affinityKey,
-            bool forceCloseConnections,
-            string prefixMessage,
-            string mitigationMessage,
-            int socketBufferSize)
-        {
-            var effectiveAffinity = forceCloseConnections ? null : affinityKey;
-
-            TlsConnectionPool.Shared.Clear(
-                uri?.Host,
-                port,
-                useTls,
-                fingerprint,
-                tlsSettings,
-                proxyOptions?.Descriptor,
-                effectiveAffinity,
-                socketBufferSize);
-
-            var messageBuilder = new StringBuilder();
-            messageBuilder.Append(prefixMessage);
-            messageBuilder.Append(uri?.Host ?? "the remote host");
-            messageBuilder.Append('.');
-            messageBuilder.Append(' ');
-            messageBuilder.Append(mitigationMessage);
-
-            return new HttpRequestException(messageBuilder.ToString(), socketException);
-        }
-        private void ReducePoolMaxConnections(
-            Uri uri,
-            int port,
-            bool useTls,
-            JA3Fingerprint fingerprint,
-            MojaveTlsSettings tlsSettings,
-            MojaveProxyOptions proxyOptions,
-            object affinityKey,
-            int observedSocketBufferSize,
-            bool socketBufferReduced,
-            bool forceCloseConnections)
-        {
-            if (uri == null)
-            {
-                return;
-            }
-
-            var descriptor = proxyOptions?.Descriptor;
-            var effectiveAffinity = forceCloseConnections ? null : affinityKey;
-            var maxConnections = _options.MaxConnectionsPerHost;
-
-            TlsConnectionPool.Shared.AdjustMaxConnections(
-                uri.Host,
-                port,
-                useTls,
-                fingerprint,
-                tlsSettings,
-                descriptor,
-                effectiveAffinity,
-                observedSocketBufferSize,
-                maxConnections);
-
-            if (!socketBufferReduced)
-            {
-                return;
-            }
-
-            var newSocketBufferSize = _options.SocketBufferSize;
-            if (newSocketBufferSize == observedSocketBufferSize)
-            {
-                return;
-            }
-
-            TlsConnectionPool.Shared.AdjustMaxConnections(
-                uri.Host,
-                port,
-                useTls,
-                fingerprint,
-                tlsSettings,
-                descriptor,
-                effectiveAffinity,
-                newSocketBufferSize,
-                maxConnections);
         }
 
         private static SocketException FindSocketException(Exception exception)

--- a/README.md
+++ b/README.md
@@ -133,6 +133,19 @@ request.ConfigureMojaveOptions(o =>
 var response = await client.SendAsync(request);
 ```
 
+### 🔐 Session affinity & isolation
+
+- **Always provide a unique `SessionAffinityKey` per logical session**. When connection reuse is enabled the handler now enforces this requirement and throws if the key is missing. You can supply it per request via `MojaveRequestOptions.SessionAffinityKey` or by constructing a dedicated `MojaveHttpClient` per session (each client generates its own key).
+- Sharing a `MojaveCookieManager` across sessions is supported as long as each session uses a distinct affinity key.
+- When you intentionally disable connection reuse by setting `ForceCloseConnectionsAfterRequest`, the affinity key is optional.
+
+### ⚙️ Proactive resource planning
+
+- Configure `SocketBufferSize` and `MaxConnectionsPerHost` up front based on the capacity of your target machines. The client no longer mutates these settings in reaction to socket exhaustion, preserving predictable behaviour across sessions.
+- Prefer smaller socket buffers (for example 8–32 KB) when running thousands of concurrent connections to reduce kernel memory pressure.
+- Monitor ephemeral port usage and adjust `MaxConnectionsPerHost` before saturation instead of relying on automatic back-off.
+- If the OS reports `SocketError.NoBufferSpaceAvailable` or `SocketError.AddressAlreadyInUse`, reduce concurrency globally rather than expecting MojaveHttpClient to do so implicitly.
+
 ### 🍪 Cookie management cheatsheet
 
 ```csharp

--- a/TlsClient.cs
+++ b/TlsClient.cs
@@ -82,8 +82,10 @@ namespace Moljave.Http
             var headerResult = await ReadHeadersAsync(activeStream, cancellationToken).ConfigureAwait(false);
             try
             {
-                var headerSpan = headerResult.HeaderBuffer.AsSpan(0, headerResult.HeaderLength);
-                ParseBodyMetadata(headerSpan,
+                var headerBuffer = headerResult.HeaderBuffer;
+                var headerLength = headerResult.HeaderLength;
+
+                ParseBodyMetadata(headerBuffer.AsSpan(0, headerLength),
                     out bool hasContentLength,
                     out int contentLength,
                     out bool isChunked);
@@ -104,7 +106,7 @@ namespace Moljave.Http
                     await ReadUntilEndAsync(responseStream, bodyWriter, cancellationToken).ConfigureAwait(false);
                 }
 
-                return HttpResponseParser.Parse(headerSpan, bodyWriter.WrittenMemory);
+                return HttpResponseParser.Parse(headerBuffer.AsSpan(0, headerLength), bodyWriter.WrittenMemory);
             }
             finally
             {

--- a/TlsClient.cs
+++ b/TlsClient.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Net;
+using System.Net.Http;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Authentication;
@@ -63,48 +64,57 @@ namespace Moljave.Http
             }
         }
 
-        public async Task<byte[]> SendRequestAsync(byte[] requestBytes, CancellationToken cancellationToken, bool useTls)
+        public async Task<HttpResponseMessage> SendRequestAsync(ReadOnlyMemory<byte> requestBuffer, CancellationToken cancellationToken, bool useTls)
         {
             if (_disposed)
             {
                 throw new ObjectDisposedException(nameof(TlsClient));
             }
 
-            if (requestBytes == null)
-            {
-                throw new ArgumentNullException(nameof(requestBytes));
-            }
-
             var activeStream = await GetActiveStreamAsync(useTls, cancellationToken).ConfigureAwait(false);
 
-            await activeStream.WriteAsync(requestBytes, 0, requestBytes.Length, cancellationToken).ConfigureAwait(false);
+            if (!requestBuffer.IsEmpty)
+            {
+                await activeStream.WriteAsync(requestBuffer, cancellationToken).ConfigureAwait(false);
+            }
             await activeStream.FlushAsync(cancellationToken).ConfigureAwait(false);
 
-            using var memoryStream = new MemoryStream();
             var headerResult = await ReadHeadersAsync(activeStream, cancellationToken).ConfigureAwait(false);
-            memoryStream.Write(headerResult.HeaderBuffer, 0, headerResult.HeaderLength);
-
-            ParseBodyMetadata(headerResult.HeaderBuffer.AsSpan(0, headerResult.HeaderLength),
-                out bool hasContentLength,
-                out int contentLength,
-                out bool isChunked);
-
-            using var responseStream = new BufferedReadStream(activeStream, headerResult.PrefetchBuffer, headerResult.PrefetchLength);
-
-            if (isChunked)
+            try
             {
-                await ReadChunkedBodyAsync(responseStream, memoryStream, cancellationToken).ConfigureAwait(false);
-            }
-            else if (hasContentLength)
-            {
-                await ReadFixedBodyAsync(responseStream, memoryStream, contentLength, cancellationToken).ConfigureAwait(false);
-            }
-            else
-            {
-                await ReadUntilEndAsync(responseStream, memoryStream, cancellationToken).ConfigureAwait(false);
-            }
+                var headerSpan = headerResult.HeaderBuffer.AsSpan(0, headerResult.HeaderLength);
+                ParseBodyMetadata(headerSpan,
+                    out bool hasContentLength,
+                    out int contentLength,
+                    out bool isChunked);
 
-            return memoryStream.ToArray();
+                using var responseStream = new BufferedReadStream(activeStream, headerResult.PrefetchBuffer, headerResult.PrefetchLength);
+                var bodyWriter = new ArrayBufferWriter<byte>(GetInitialBodyBufferSize(hasContentLength ? contentLength : -1));
+
+                if (isChunked)
+                {
+                    await ReadChunkedBodyAsync(responseStream, bodyWriter, cancellationToken).ConfigureAwait(false);
+                }
+                else if (hasContentLength)
+                {
+                    await ReadFixedBodyAsync(responseStream, bodyWriter, contentLength, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await ReadUntilEndAsync(responseStream, bodyWriter, cancellationToken).ConfigureAwait(false);
+                }
+
+                return HttpResponseParser.Parse(headerSpan, bodyWriter.WrittenMemory);
+            }
+            finally
+            {
+                if (headerResult.PrefetchBuffer.Length > 0)
+                {
+                    ArrayPool<byte>.Shared.Return(headerResult.PrefetchBuffer);
+                }
+
+                ArrayPool<byte>.Shared.Return(headerResult.HeaderBuffer);
+            }
         }
 
         public async Task<Stream> CreateTransportStreamAsync(CancellationToken cancellationToken)
@@ -897,7 +907,7 @@ namespace Moljave.Http
             }
         }
 
-        private static async Task ReadChunkedBodyAsync(Stream stream, MemoryStream destination, CancellationToken cancellationToken)
+        private static async Task ReadChunkedBodyAsync(Stream stream, IBufferWriter<byte> destination, CancellationToken cancellationToken)
         {
             var buffer = ArrayPool<byte>.Shared.Rent(8192);
 
@@ -940,7 +950,7 @@ namespace Moljave.Http
                             throw new IOException("Unexpected end of stream while reading chunked body.");
                         }
 
-                        destination.Write(buffer, 0, read);
+                        WriteToBuffer(destination, buffer.AsSpan(0, read));
                         remaining -= read;
                     }
 
@@ -953,7 +963,7 @@ namespace Moljave.Http
             }
         }
 
-        private static async Task ReadFixedBodyAsync(Stream stream, MemoryStream destination, int length, CancellationToken cancellationToken)
+        private static async Task ReadFixedBodyAsync(Stream stream, IBufferWriter<byte> destination, int length, CancellationToken cancellationToken)
         {
             var buffer = ArrayPool<byte>.Shared.Rent(8192);
 
@@ -969,7 +979,7 @@ namespace Moljave.Http
                         break;
                     }
 
-                    destination.Write(buffer, 0, read);
+                    WriteToBuffer(destination, buffer.AsSpan(0, read));
                     remaining -= read;
                 }
             }
@@ -979,7 +989,7 @@ namespace Moljave.Http
             }
         }
 
-        private static async Task ReadUntilEndAsync(Stream stream, MemoryStream destination, CancellationToken cancellationToken)
+        private static async Task ReadUntilEndAsync(Stream stream, IBufferWriter<byte> destination, CancellationToken cancellationToken)
         {
             var buffer = ArrayPool<byte>.Shared.Rent(8192);
 
@@ -993,13 +1003,53 @@ namespace Moljave.Http
                         break;
                     }
 
-                    destination.Write(buffer, 0, read);
+                    WriteToBuffer(destination, buffer.AsSpan(0, read));
                 }
             }
             finally
             {
                 ArrayPool<byte>.Shared.Return(buffer);
             }
+        }
+
+        private static int GetInitialBodyBufferSize(int contentLength)
+        {
+            const int DefaultSize = 1024;
+            const int MaxInitialSize = 64 * 1024;
+
+            if (contentLength <= 0)
+            {
+                return DefaultSize;
+            }
+
+            if (contentLength < DefaultSize)
+            {
+                return DefaultSize;
+            }
+
+            if (contentLength > MaxInitialSize)
+            {
+                return MaxInitialSize;
+            }
+
+            return contentLength;
+        }
+
+        private static void WriteToBuffer(IBufferWriter<byte> writer, ReadOnlySpan<byte> source)
+        {
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            if (source.Length == 0)
+            {
+                return;
+            }
+
+            var span = writer.GetSpan(source.Length);
+            source.CopyTo(span);
+            writer.Advance(source.Length);
         }
 
         private static void ParseBodyMetadata(
@@ -1226,48 +1276,52 @@ namespace Moljave.Http
 
         private static async Task<HeaderReadResult> ReadHeadersAsync(Stream stream, CancellationToken cancellationToken)
         {
-            var writer = new ArrayBufferWriter<byte>(4096);
-            var buffer = ArrayPool<byte>.Shared.Rent(8192);
-
-            try
+            if (stream == null)
             {
-                while (true)
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            var headerBuffer = ArrayPool<byte>.Shared.Rent(4096);
+            var written = 0;
+
+            while (true)
+            {
+                if (written == headerBuffer.Length)
                 {
-                    var read = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
-                    if (read == 0)
-                    {
-                        throw new IOException("Unexpected end of stream while reading headers.");
-                    }
+                    var newBuffer = ArrayPool<byte>.Shared.Rent(headerBuffer.Length * 2);
+                    Buffer.BlockCopy(headerBuffer, 0, newBuffer, 0, written);
+                    ArrayPool<byte>.Shared.Return(headerBuffer);
+                    headerBuffer = newBuffer;
+                }
 
-                    var previousLength = writer.WrittenCount;
-                    writer.Write(buffer.AsSpan(0, read));
-                    var span = writer.WrittenSpan;
-                    var searchStart = previousLength >= 3 ? previousLength : 3;
+                var read = await stream.ReadAsync(headerBuffer.AsMemory(written, headerBuffer.Length - written), cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    ArrayPool<byte>.Shared.Return(headerBuffer);
+                    throw new IOException("Unexpected end of stream while reading headers.");
+                }
 
-                    for (int i = searchStart; i < span.Length; i++)
+                var previous = written;
+                written += read;
+                var searchStart = previous >= 3 ? previous : 3;
+
+                for (int i = searchStart; i <= written - 4; i++)
+                {
+                    if (headerBuffer[i - 3] == 13 && headerBuffer[i - 2] == 10 && headerBuffer[i - 1] == 13 && headerBuffer[i] == 10)
                     {
-                        if (span[i - 3] == 13 && span[i - 2] == 10 && span[i - 1] == 13 && span[i] == 10)
+                        var headerLength = i + 1;
+                        var leftoverCount = written - headerLength;
+                        byte[] prefetch = Array.Empty<byte>();
+
+                        if (leftoverCount > 0)
                         {
-                            var headerLength = i + 1;
-                            var headerBuffer = new byte[headerLength];
-                            span.Slice(0, headerLength).CopyTo(headerBuffer);
-
-                            var leftoverCount = span.Length - headerLength;
-                            byte[] prefetch = Array.Empty<byte>();
-                            if (leftoverCount > 0)
-                            {
-                                prefetch = new byte[leftoverCount];
-                                span.Slice(headerLength, leftoverCount).CopyTo(prefetch);
-                            }
-
-                            return new HeaderReadResult(headerBuffer, headerLength, prefetch, leftoverCount);
+                            prefetch = ArrayPool<byte>.Shared.Rent(leftoverCount);
+                            Buffer.BlockCopy(headerBuffer, headerLength, prefetch, 0, leftoverCount);
                         }
+
+                        return new HeaderReadResult(headerBuffer, headerLength, prefetch, leftoverCount);
                     }
                 }
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
             }
         }
 
@@ -1528,6 +1582,7 @@ namespace Moljave.Http
 
                 _disposed = true;
                 ArrayPool<byte>.Shared.Return(_buffer);
+                _prefetch = Array.Empty<byte>();
             }
 
             private int ReadFromPrefetch(Span<byte> destination)

--- a/TlsClient.cs
+++ b/TlsClient.cs
@@ -13,6 +13,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Runtime.InteropServices;
 
 namespace Moljave.Http
 {
@@ -75,7 +76,14 @@ namespace Moljave.Http
 
             if (!requestBuffer.IsEmpty)
             {
-                await activeStream.WriteAsync(requestBuffer, cancellationToken).ConfigureAwait(false);
+                ArraySegment<byte> segment;
+                if (!MemoryMarshal.TryGetArray(requestBuffer, out segment))
+                {
+                    var copy = requestBuffer.ToArray();
+                    segment = new ArraySegment<byte>(copy, 0, copy.Length);
+                }
+
+                await activeStream.WriteAsync(segment.Array, segment.Offset, segment.Count, cancellationToken).ConfigureAwait(false);
             }
             await activeStream.FlushAsync(cancellationToken).ConfigureAwait(false);
 

--- a/TlsConnectionPool.cs
+++ b/TlsConnectionPool.cs
@@ -65,18 +65,17 @@ namespace Moljave.Http
 
             try
             {
-                while (state.Queue.TryDequeue(out var existing))
+                while (state.TryTakeClient(out var pooledClient))
                 {
-                    var client = existing.Client;
-                    if (client != null && client.IsReusable)
+                    if (pooledClient != null && pooledClient.IsReusable)
                     {
-                        return new TlsClientLease(this, state, client);
+                        return new TlsClientLease(this, state, pooledClient);
                     }
 
-                    client?.Dispose();
+                    pooledClient?.Dispose();
                 }
 
-                var client = new TlsClient(
+                var newClient = new TlsClient(
                     host,
                     port,
                     fingerprint,
@@ -85,7 +84,7 @@ namespace Moljave.Http
                     certificateValidationCallback,
                     socketBufferSize);
 
-                return new TlsClientLease(this, state, client);
+                return new TlsClientLease(this, state, newClient);
             }
             catch
             {
@@ -344,7 +343,17 @@ namespace Moljave.Http
             private int _maxConnections;
             private int _reservedPermits;
 
-            public ConcurrentQueue<PooledConnection> Queue => _queue;
+            public bool TryTakeClient(out TlsClient client)
+            {
+                while (_queue.TryDequeue(out var connection))
+                {
+                    client = connection.Client;
+                    return true;
+                }
+
+                client = null;
+                return false;
+            }
 
             public SemaphoreSlim GetSemaphore(int maxConnections)
             {


### PR DESCRIPTION
## Summary
- stream HTTP/1.1 responses without redundant buffering by parsing headers from pooled arrays and reading bodies into lightweight writers
- replace byte-array request handling with reusable payload structs, enforce non-null SessionAffinityKey for reusable connections, and remove reactive socket tuning logic
- update documentation with guidance for session affinity management and proactive resource planning

## Testing
- `dotnet build` *(fails: .NET SDK not installed in CI image)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dd672e8848332aafb48a44b3956a2)