### PR TITLE
Handle invalid Set-Cookie headers during cookie updates

### DIFF
--- a/MojaveCookieManager.cs
+++ b/MojaveCookieManager.cs
@@ -203,9 +203,54 @@ namespace Moljave.Http
             {
                 foreach (var header in setCookieHeaders.Where(h => !string.IsNullOrWhiteSpace(h)))
                 {
-                    _container.SetCookies(uri, header);
+                    var trimmedHeader = header.Trim();
+                    if (trimmedHeader.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    if (TrySetCookies(uri, trimmedHeader))
+                    {
+                        continue;
+                    }
+
+                    var sanitized = SanitizeCookieHeader(trimmedHeader);
+                    TrySetCookies(uri, sanitized);
                 }
             }
+        }
+
+        private bool TrySetCookies(Uri uri, string header)
+        {
+            if (string.IsNullOrWhiteSpace(header))
+            {
+                return false;
+            }
+
+            try
+            {
+                _container.SetCookies(uri, header);
+                return true;
+            }
+            catch (CookieException)
+            {
+                return false;
+            }
+        }
+
+        private static string SanitizeCookieHeader(string header)
+        {
+            if (string.IsNullOrWhiteSpace(header))
+            {
+                return string.Empty;
+            }
+
+            var segments = header
+                .Split(';')
+                .Select(segment => segment.Trim())
+                .Where(segment => !string.IsNullOrWhiteSpace(segment) && !segment.StartsWith("$", StringComparison.Ordinal));
+
+            return string.Join("; ", segments);
         }
 
         private IEnumerable<Cookie> EnumerateCookiesInternal()


### PR DESCRIPTION
## Summary
- guard MojaveCookieManager against malformed Set-Cookie headers
- skip or sanitize headers that CookieContainer cannot parse

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f8e19c67083328964f8770a4d1db8)