### PR TITLE
Enhance cookie control, proxy handling, and JA3 presets

### DIFF
--- a/Examples.md
+++ b/Examples.md
@@ -1,0 +1,67 @@
+# MoljaveClient Examples
+
+## Configure the client with presets and cookies
+```csharp
+var options = new MojaveHttpClientOptions
+{
+    FingerprintPreset = Ja3Preset.Chrome,
+    MaxConnectionRetries = 1,
+    ConnectionRetryDelay = TimeSpan.FromMilliseconds(100)
+};
+
+// keep only the cookies you need
+options.CookieManager.RemoveCookies(new List<string> { "session", "auth_token" });
+
+using var client = new MojaveHttpClient(options);
+client.CookieManager.ChangeCookieValue("session", "fresh-value");
+```
+
+## Send HTTP/1.1 requests through an HTTP proxy
+```csharp
+var request = new HttpRequestMessage(HttpMethod.Get, "http://example.org/api");
+
+request.ConfigureMojaveOptions(o =>
+{
+    o.Proxy = ProxyParser.TryParse("http://127.0.0.1:8080", out var proxy)
+        ? proxy
+        : MojaveProxyOptions.NoProxy;
+    o.Timeout = TimeSpan.FromSeconds(5);
+});
+
+using var client = new MojaveHttpClient();
+var response = await client.SendAsync(request);
+```
+
+## Pin a custom JA3 fingerprint
+```csharp
+var customJa3 = JA3FingerprintParser.Parse(
+    "771,4866-4867-4865-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,0-23-65281-10-11-35-16-5-13-18-45-43-51-27-21-41-28-19,29-23-24,0");
+
+using var client = new MojaveHttpClient();
+client.UseFingerprintProvider(() => customJa3, rotateImmediately: true);
+```
+
+## Rotate proxies while keeping cookies
+```csharp
+var proxies = new Queue<string>(new[]
+{
+    "socks5://127.0.0.1:1080",
+    "http://127.0.0.1:8888"
+});
+
+var options = new MojaveHttpClientOptions
+{
+    ProxyResolver = () =>
+    {
+        var next = proxies.Dequeue();
+        proxies.Enqueue(next);
+        return ProxyParser.TryParse(next, out var proxy)
+            ? proxy
+            : MojaveProxyOptions.NoProxy;
+    }
+};
+
+using var client = new MojaveHttpClient(options);
+client.CookieManager.ChangeCookieValue("session", Guid.NewGuid().ToString("N"));
+var rotatedResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "https://example.com"));
+```

--- a/HttpRequestStringifier.cs
+++ b/HttpRequestStringifier.cs
@@ -9,7 +9,7 @@ namespace Moljave.Http
 {
     public static class HttpRequestStringifier
     {
-        public static async Task<byte[]> Stringify(HttpRequestMessage request)
+        public static async Task<byte[]> Stringify(HttpRequestMessage request, bool useAbsoluteUri = false)
         {
             if (request == null)
             {
@@ -17,15 +17,31 @@ namespace Moljave.Http
             }
 
             var uri = request.RequestUri ?? throw new InvalidOperationException("RequestUri cannot be null");
-            var target = uri.PathAndQuery;
-            if (string.IsNullOrEmpty(target))
-            {
-                target = "/";
-            }
+            string target;
 
-            if (!string.IsNullOrEmpty(uri.Fragment))
+            if (useAbsoluteUri)
             {
-                target += uri.Fragment;
+                var schemeAndServer = uri.GetComponents(UriComponents.SchemeAndServer, UriFormat.UriEscaped);
+                var pathAndQuery = uri.GetComponents(UriComponents.PathAndQuery, UriFormat.UriEscaped);
+                if (string.IsNullOrEmpty(pathAndQuery))
+                {
+                    pathAndQuery = "/";
+                }
+
+                target = string.Concat(schemeAndServer, pathAndQuery);
+            }
+            else
+            {
+                target = uri.PathAndQuery;
+                if (string.IsNullOrEmpty(target))
+                {
+                    target = "/";
+                }
+
+                if (!string.IsNullOrEmpty(uri.Fragment))
+                {
+                    target += uri.Fragment;
+                }
             }
 
             byte[] contentBytes = Array.Empty<byte>();

--- a/JA3FingerprintFactory.cs
+++ b/JA3FingerprintFactory.cs
@@ -1,69 +1,49 @@
 ﻿using System;
-using System.Collections.Generic;
+
 namespace Moljave.Http
 {
-    public enum BrowserJa3Profile
+    public enum Ja3Preset
     {
-        Chrome,
-        Custom
+        Disabled,
+        Default,
+        Chrome
     }
 
     public static class JA3FingerprintFactory
     {
-        private static readonly Dictionary<BrowserJa3Profile, string[]> Ja3Presets = new()
+        private static readonly JA3Fingerprint[] s_defaultPreset =
         {
-            {
-                BrowserJa3Profile.Chrome,
-                new[]
-                {
-                    "771,4866-4867-4865-49195-49199-49196-49200-49171-49172-49199-52393-52392-156-157-47-53,0-23-65281-10-11-35-16-5-13-18-51-45-43-27-21-41-28-19,29-23-24,0",
-                    "771,4866-4867-4865-49195-49199-49196-49200-52393-52392-49171-49172-49199-49195-49196-52394-49172-49171-156-157-57-47-53,0-10-11-35-13-18-23-45-51-16-65281-27-43-28-29-41-65037-17513,29-23-24,0",
-                    "771,4866-4867-4865-49195-49199-49196-49200-52393-52392-49188-49192-49187-49191-49162-49172-156-157-47-53,0-10-11-13-16-18-23-27-28-29-35-43-45-51-17513-0,23-24,0"
-                }
-            },
-            {
-                BrowserJa3Profile.Custom,
-                Array.Empty<string>()
-            }
+            JA3Fingerprint.Default
         };
 
-        private static readonly Lazy<Dictionary<BrowserJa3Profile, JA3Fingerprint[]>> s_cachedFingerprints = new(() =>
+        private static readonly Lazy<JA3Fingerprint[]> s_chromePreset = new(() => new[]
         {
-            var cache = new Dictionary<BrowserJa3Profile, JA3Fingerprint[]>(Ja3Presets.Count);
-
-            foreach (var (profile, presets) in Ja3Presets)
-            {
-                if (presets == null || presets.Length == 0)
-                {
-                    cache[profile] = Array.Empty<JA3Fingerprint>();
-                    continue;
-                }
-
-                var parsed = new JA3Fingerprint[presets.Length];
-                for (int i = 0; i < presets.Length; i++)
-                {
-                    parsed[i] = JA3FingerprintParser.Parse(presets[i]);
-                }
-
-                cache[profile] = parsed;
-            }
-
-            return cache;
+            JA3FingerprintParser.Parse("771,4866-4867-4865-49195-49199-49196-49200-49171-49172-49199-52393-52392-156-157-47-53,0-23-65281-10-11-35-16-5-13-18-51-45-43-27-21-41-28-19,29-23-24,0"),
+            JA3FingerprintParser.Parse("771,4866-4867-4865-49195-49199-49196-49200-52393-52392-49171-49172-49199-49195-49196-52394-49172-49171-156-157-57-47-53,0-10-11-35-13-18-23-45-51-16-65281-27-43-28-29-41-65037-17513,29-23-24,0"),
+            JA3FingerprintParser.Parse("771,4866-4867-4865-49195-49199-49196-49200-52393-52392-49188-49192-49187-49191-49162-49172-156-157-47-53,0-10-11-13-16-18-23-27-28-29-35-43-45-51-17513-0,23-24,0")
         });
 
-        private static readonly Random _rnd = new();
-
-        public static JA3Fingerprint GetFingerprint(BrowserJa3Profile profile, string custom = null)
+        public static JA3Fingerprint GetFingerprint(Ja3Preset preset)
         {
-            if (profile == BrowserJa3Profile.Custom)
+            return preset switch
             {
-                if (string.IsNullOrWhiteSpace(custom)) throw new ArgumentNullException(nameof(custom));
-                return JA3FingerprintParser.Parse(custom);
-            }
-            if (!s_cachedFingerprints.Value.TryGetValue(profile, out var cachedFingerprints) || cachedFingerprints.Length == 0)
-                throw new NotSupportedException($"Profile {profile} not implemented.");
+                Ja3Preset.Disabled => null,
+                Ja3Preset.Default => s_defaultPreset[0],
+                Ja3Preset.Chrome =>
+                    GetRandomChromeFingerprint(),
+                _ => throw new ArgumentOutOfRangeException(nameof(preset), preset, "Unknown JA3 preset.")
+            };
+        }
 
-            return cachedFingerprints[_rnd.Next(cachedFingerprints.Length)];
+        private static JA3Fingerprint GetRandomChromeFingerprint()
+        {
+            var presets = s_chromePreset.Value;
+            if (presets.Length == 0)
+            {
+                throw new NotSupportedException("Chrome JA3 preset is not configured.");
+            }
+
+            return presets[Random.Shared.Next(presets.Length)];
         }
     }
 }

--- a/MojaveCookieManager.cs
+++ b/MojaveCookieManager.cs
@@ -108,6 +108,49 @@ namespace Moljave.Http
             }
         }
 
+        public void ChangeCookieValue(string name, string newValue)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            lock (_syncRoot)
+            {
+                var comparer = StringComparer.OrdinalIgnoreCase;
+                var updated = new List<Cookie>();
+                var modified = false;
+                var targetValue = newValue ?? string.Empty;
+
+                foreach (var cookie in EnumerateCookiesInternal())
+                {
+                    if (cookie == null)
+                    {
+                        continue;
+                    }
+
+                    var clone = CloneCookie(cookie);
+                    var cloneName = clone.Name ?? string.Empty;
+                    if (comparer.Equals(cloneName, name))
+                    {
+                        if (!string.Equals(clone.Value, targetValue, StringComparison.Ordinal) || clone.Expired)
+                        {
+                            clone.Value = targetValue;
+                            clone.Expired = false;
+                            modified = true;
+                        }
+                    }
+
+                    updated.Add(clone);
+                }
+
+                if (modified)
+                {
+                    ReplaceContainerWith(updated);
+                }
+            }
+        }
+
         public void RemoveCookie(string domain, string name, string path = "/")
         {
             if (string.IsNullOrWhiteSpace(domain))
@@ -128,6 +171,94 @@ namespace Moljave.Http
             lock (_syncRoot)
             {
                 _container.Add(cookie);
+            }
+        }
+
+        public void RemoveCookie(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            lock (_syncRoot)
+            {
+                var comparer = StringComparer.OrdinalIgnoreCase;
+                var retained = new List<Cookie>();
+                var removed = false;
+
+                foreach (var cookie in EnumerateCookiesInternal())
+                {
+                    if (cookie == null)
+                    {
+                        continue;
+                    }
+
+                    var cookieName = cookie.Name ?? string.Empty;
+                    if (comparer.Equals(cookieName, name))
+                    {
+                        removed = true;
+                        continue;
+                    }
+
+                    retained.Add(CloneCookie(cookie));
+                }
+
+                if (removed)
+                {
+                    ReplaceContainerWith(retained);
+                }
+            }
+        }
+
+        public void RemoveCookies(List<string> excludeNames)
+        {
+            lock (_syncRoot)
+            {
+                HashSet<string> exclusions = null;
+                if (excludeNames != null && excludeNames.Count > 0)
+                {
+                    exclusions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var name in excludeNames)
+                    {
+                        if (!string.IsNullOrWhiteSpace(name))
+                        {
+                            exclusions.Add(name);
+                        }
+                    }
+                }
+
+                if (exclusions == null || exclusions.Count == 0)
+                {
+                    _container = new CookieContainer();
+                    return;
+                }
+
+                var retained = new List<Cookie>();
+                var modified = false;
+
+                foreach (var cookie in EnumerateCookiesInternal())
+                {
+                    if (cookie == null)
+                    {
+                        continue;
+                    }
+
+                    var cookieName = cookie.Name ?? string.Empty;
+                    if (exclusions.Contains(cookieName))
+                    {
+                        retained.Add(CloneCookie(cookie));
+                    }
+                    else
+                    {
+                        modified = true;
+                    }
+                }
+
+                if (modified)
+                {
+                    ReplaceContainerWith(retained);
+                }
             }
         }
 
@@ -292,12 +423,25 @@ namespace Moljave.Http
 
         private static Cookie CloneCookie(Cookie cookie)
         {
-            return new Cookie(cookie?.Name ?? string.Empty, cookie?.Value ?? string.Empty, cookie?.Path ?? "/", cookie?.Domain ?? string.Empty)
+            if (cookie == null)
             {
-                Expires = cookie?.Expires ?? DateTime.MinValue,
-                HttpOnly = cookie?.HttpOnly ?? false,
-                Secure = cookie?.Secure ?? false
+                return new Cookie(string.Empty, string.Empty);
+            }
+
+            var clone = new Cookie(cookie.Name ?? string.Empty, cookie.Value ?? string.Empty, cookie.Path ?? "/", cookie.Domain ?? string.Empty)
+            {
+                Expires = cookie.Expires,
+                HttpOnly = cookie.HttpOnly,
+                Secure = cookie.Secure,
+                Discard = cookie.Discard,
+                Comment = cookie.Comment,
+                CommentUri = cookie.CommentUri,
+                Port = cookie.Port,
+                Version = cookie.Version,
+                Expired = cookie.Expired
             };
+
+            return clone;
         }
 
         private static bool IsDomainMatch(string cookieDomain, string targetDomain)
@@ -326,6 +470,33 @@ namespace Moljave.Http
             }
 
             return domain.Trim().TrimStart('.').ToLowerInvariant();
+        }
+
+        private void ReplaceContainerWith(IEnumerable<Cookie> cookies)
+        {
+            var updated = new CookieContainer();
+
+            if (cookies != null)
+            {
+                foreach (var cookie in cookies)
+                {
+                    if (cookie == null)
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        updated.Add(cookie);
+                    }
+                    catch (CookieException)
+                    {
+                        // Ignore invalid cookies to avoid corrupting the container.
+                    }
+                }
+            }
+
+            _container = updated;
         }
     }
 }

--- a/MojaveHttpClientOptions.cs
+++ b/MojaveHttpClientOptions.cs
@@ -22,8 +22,45 @@ namespace Moljave.Http
         private int _socketBufferSize = 8 * 1024;
         private int _forceConnectionCloseAfterRequest = 0;
 
-        public Func<JA3Fingerprint> FingerprintProvider { get; set; } =
-            () => JA3FingerprintFactory.GetFingerprint(BrowserJa3Profile.Chrome);
+        private Func<JA3Fingerprint> _fingerprintProvider;
+        private bool _fingerprintProviderOverridden;
+        private Ja3Preset _fingerprintPreset = Ja3Preset.Chrome;
+
+        public MojaveHttpClientOptions()
+        {
+            _fingerprintProvider = CreatePresetProvider(_fingerprintPreset);
+        }
+
+        public Func<JA3Fingerprint> FingerprintProvider
+        {
+            get => _fingerprintProvider;
+            set
+            {
+                if (value == null)
+                {
+                    _fingerprintProvider = CreatePresetProvider(_fingerprintPreset);
+                    _fingerprintProviderOverridden = false;
+                }
+                else
+                {
+                    _fingerprintProvider = value;
+                    _fingerprintProviderOverridden = true;
+                }
+            }
+        }
+
+        public Ja3Preset FingerprintPreset
+        {
+            get => _fingerprintPreset;
+            set
+            {
+                _fingerprintPreset = value;
+                if (!_fingerprintProviderOverridden)
+                {
+                    _fingerprintProvider = CreatePresetProvider(value);
+                }
+            }
+        }
 
         public bool EnableJa3Fingerprinting { get; set; } = true;
 
@@ -238,6 +275,15 @@ namespace Moljave.Http
 
             return current;
         }
+
+        private static Func<JA3Fingerprint> CreatePresetProvider(Ja3Preset preset)
+        {
+            return preset switch
+            {
+                Ja3Preset.Disabled => () => null,
+                _ => () => JA3FingerprintFactory.GetFingerprint(preset)
+            };
+        }
     }
 
     public sealed class MojaveRequestOptions
@@ -278,4 +324,5 @@ namespace Moljave.Http
         public RemoteCertificateValidationCallback CertificateValidationCallback { get; set; }
             = (_, _, _, _) => true;
     }
+
 }

--- a/MojaveHttpMessageHandler.cs
+++ b/MojaveHttpMessageHandler.cs
@@ -146,7 +146,7 @@ namespace Moljave.Http
 
         private JA3Fingerprint GetEffectiveFingerprint(MojaveRequestOptions requestOptions)
         {
-            if (!_options.EnableJa3Fingerprinting)
+            if (!_options.EnableJa3Fingerprinting || _options.FingerprintPreset == Ja3Preset.Disabled)
             {
                 return null;
             }
@@ -156,7 +156,17 @@ namespace Moljave.Http
                 return requestOptions.Fingerprint;
             }
 
-            return _options.FingerprintProvider?.Invoke() ?? JA3Fingerprint.Default;
+            var resolved = _options.FingerprintProvider?.Invoke();
+            if (resolved != null)
+            {
+                return resolved;
+            }
+
+            var preset = _options.FingerprintPreset == Ja3Preset.Disabled
+                ? Ja3Preset.Default
+                : _options.FingerprintPreset;
+
+            return JA3FingerprintFactory.GetFingerprint(preset);
         }
 
         private static bool IsRedirect(HttpStatusCode statusCode)
@@ -198,6 +208,7 @@ namespace Moljave.Http
             var targetPort = uri.IsDefaultPort ? (useTls ? 443 : 80) : uri.Port;
 
             Exception lastException = null;
+            var lastUsedAbsoluteUri = false;
 
             for (int attempt = 0; attempt <= maxRetries; attempt++)
             {
@@ -208,6 +219,15 @@ namespace Moljave.Http
                 TlsClientLease lease = null;
                 CancellationTokenSource waitCts = null;
                 CancellationTokenSource linkedCts = null;
+                var sendAbsoluteUri = ShouldSendAbsoluteUri(proxyOptions, useTls);
+                if (sendAbsoluteUri != lastUsedAbsoluteUri)
+                {
+                    requestPayloadDirty = true;
+                }
+                if (sendAbsoluteUri && EnsureProxyHeadersForHttpProxy(request, proxyOptions?.Descriptor))
+                {
+                    requestPayloadDirty = true;
+                }
 
                 try
                 {
@@ -240,8 +260,9 @@ namespace Moljave.Http
 
                     if (requestPayloadDirty || cachedRequestPayload == null)
                     {
-                        cachedRequestPayload = await HttpRequestStringifier.Stringify(request).ConfigureAwait(false);
+                        cachedRequestPayload = await HttpRequestStringifier.Stringify(request, sendAbsoluteUri).ConfigureAwait(false);
                         requestPayloadDirty = false;
+                        lastUsedAbsoluteUri = sendAbsoluteUri;
                     }
 
                     var requestPayload = cachedRequestPayload;
@@ -551,6 +572,7 @@ namespace Moljave.Http
                             var connector = new TlsClient(
                                 context.DnsEndPoint.Host,
                                 context.DnsEndPoint.Port,
+                                useTls: true,
                                 fingerprint,
                                 proxyOptions.Descriptor,
                                 tlsSettings,
@@ -779,6 +801,91 @@ namespace Moljave.Http
             }
 
             return cookieManager;
+        }
+
+        private static bool ShouldSendAbsoluteUri(MojaveProxyOptions proxyOptions, bool targetUsesTls)
+        {
+            var descriptor = proxyOptions?.Descriptor;
+            if (descriptor == null)
+            {
+                return false;
+            }
+
+            if (targetUsesTls)
+            {
+                return false;
+            }
+
+            return descriptor.Scheme == ProxyScheme.Http || descriptor.Scheme == ProxyScheme.Https;
+        }
+
+        private static bool EnsureProxyHeadersForHttpProxy(HttpRequestMessage request, ProxyDescriptor descriptor)
+        {
+            if (request == null || descriptor == null)
+            {
+                return false;
+            }
+
+            var modified = false;
+
+            if (!request.Headers.Contains("Proxy-Connection"))
+            {
+                request.Headers.TryAddWithoutValidation("Proxy-Connection", "Keep-Alive");
+                modified = true;
+            }
+
+            var headerValue = BuildProxyAuthorizationHeader(descriptor.Credentials);
+
+            if (string.IsNullOrEmpty(headerValue))
+            {
+                if (request.Headers.Contains("Proxy-Authorization"))
+                {
+                    request.Headers.Remove("Proxy-Authorization");
+                    modified = true;
+                }
+            }
+            else
+            {
+                var needsUpdate = true;
+                if (request.Headers.TryGetValues("Proxy-Authorization", out var existingValues))
+                {
+                    foreach (var existing in existingValues)
+                    {
+                        if (string.Equals(existing, headerValue, StringComparison.Ordinal))
+                        {
+                            needsUpdate = false;
+                            break;
+                        }
+                    }
+                }
+
+                if (needsUpdate)
+                {
+                    request.Headers.Remove("Proxy-Authorization");
+                    request.Headers.TryAddWithoutValidation("Proxy-Authorization", headerValue);
+                    modified = true;
+                }
+            }
+
+            return modified;
+        }
+
+        private static string BuildProxyAuthorizationHeader(NetworkCredential credential)
+        {
+            if (credential == null)
+            {
+                return null;
+            }
+
+            var username = credential.UserName ?? string.Empty;
+            if (!string.IsNullOrEmpty(credential.Domain))
+            {
+                username = $"{credential.Domain}\\{username}";
+            }
+
+            var password = credential.Password ?? string.Empty;
+            var token = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
+            return $"Basic {token}";
         }
 
         private static async Task DelayForRetryAsync(

--- a/MoljaveHttpClient.cs
+++ b/MoljaveHttpClient.cs
@@ -71,7 +71,8 @@ namespace Moljave.Http
             PlatformRequirements.EnsureSupportedWindows();
 
             _options = options ?? throw new ArgumentNullException(nameof(options));
-            _ja3FingerprintingEnabled = _options.EnableJa3Fingerprinting;
+            _ja3FingerprintingEnabled = _options.EnableJa3Fingerprinting &&
+                _options.FingerprintPreset != Ja3Preset.Disabled;
 
             _cookieManager = _options.CookieManager ?? new MojaveCookieManager();
             _options.CookieManager = _cookieManager;
@@ -387,7 +388,7 @@ namespace Moljave.Http
 
             lock (_fingerprintLock)
             {
-                _currentFingerprint = (_fingerprintFactory ?? DefaultFingerprintFactory)();
+                _currentFingerprint = (_fingerprintFactory ?? ResolvePresetFactory())();
             }
         }
 
@@ -724,7 +725,7 @@ namespace Moljave.Http
         {
             lock (_fingerprintLock)
             {
-                _fingerprintFactory = fingerprintProvider ?? DefaultFingerprintFactory;
+                _fingerprintFactory = fingerprintProvider ?? ResolvePresetFactory();
                 _currentFingerprint = null;
             }
         }
@@ -741,9 +742,17 @@ namespace Moljave.Http
         {
             lock (_fingerprintLock)
             {
-                _currentFingerprint ??= (_fingerprintFactory ?? DefaultFingerprintFactory)();
+                _currentFingerprint ??= (_fingerprintFactory ?? ResolvePresetFactory())();
                 return _currentFingerprint;
             }
+        }
+
+        private Func<JA3Fingerprint> ResolvePresetFactory()
+        {
+            return () => JA3FingerprintFactory.GetFingerprint(
+                _options.FingerprintPreset == Ja3Preset.Disabled
+                    ? Ja3Preset.Default
+                    : _options.FingerprintPreset);
         }
 
         private static MojaveHttpClientOptions BuildOptions(Action<MojaveHttpClientOptions> configure)
@@ -752,8 +761,5 @@ namespace Moljave.Http
             configure?.Invoke(options);
             return options;
         }
-
-        private static JA3Fingerprint DefaultFingerprintFactory()
-            => JA3FingerprintFactory.GetFingerprint(BrowserJa3Profile.Chrome);
     }
 }

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ options.DelegatingHandlerFactories.Add(() => new MyTelemetryHandler());
 
 using var client = new MojaveHttpClient(options);
 
+// choose a built-in JA3 preset (Disabled, Default, Chrome)
+options.FingerprintPreset = Ja3Preset.Chrome;
+
 // rotate to a fresh JA3 fingerprint whenever you need
 client.RotateFingerprint();
 
@@ -136,11 +139,15 @@ var response = await client.SendAsync(request);
 ### 🍪 Cookie management cheatsheet
 
 ```csharp
-// Update a cookie value on the fly
-client.CookieManager.SetCookie("example.com", "session", "new-value");
+// Update a cookie value wherever it exists
+client.CookieManager.ChangeCookieValue("session", "new-value");
 
-// Remove a specific cookie
+// Remove a cookie globally or for a specific domain
+client.CookieManager.RemoveCookie("session");
 client.CookieManager.RemoveCookie("example.com", "session");
+
+// Drop every cookie except the ones you want to keep
+client.CookieManager.RemoveCookies(new List<string> { "session", "auth_token" });
 
 // Clear cookies for a single domain or every domain
 client.ClearCookiesForDomain("example.com");
@@ -168,9 +175,9 @@ client.EnableProxy();
 ## 🧪 Custom JA3 Example
 
 ```csharp
-var ja3 = JA3FingerprintFactory.GetFingerprint(
-    BrowserJa3Profile.Custom,
-    "771,4866-4867-4865-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,0-23-65281-10-11-35-16-5-13-18-45-43-51-27-21-41-28-19,29-23-24,0"
-);
+// Parse a custom JA3 fingerprint and pin it to the client
+var ja3 = JA3FingerprintParser.Parse(
+    "771,4866-4867-4865-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,0-23-65281-10-11-35-16-5-13-18-45-43-51-27-21-41-28-19,29-23-24,0");
 
-
+client.UseFingerprintProvider(() => ja3);
+```

--- a/TlsClient.cs
+++ b/TlsClient.cs
@@ -23,6 +23,7 @@ namespace Moljave.Http
 
         private readonly string _host;
         private readonly int _port;
+        private readonly bool _targetUsesTls;
         private readonly JA3Fingerprint _fingerprint;
         private readonly ProxyDescriptor _proxy;
         private readonly MojaveTlsSettings _tlsSettings;
@@ -37,6 +38,7 @@ namespace Moljave.Http
         public TlsClient(
             string host,
             int port,
+            bool targetUsesTls,
             JA3Fingerprint fingerprint,
             ProxyDescriptor proxy,
             MojaveTlsSettings tlsSettings,
@@ -45,6 +47,7 @@ namespace Moljave.Http
         {
             _host = host ?? throw new ArgumentNullException(nameof(host));
             _port = port;
+            _targetUsesTls = targetUsesTls;
             _fingerprint = fingerprint;
             _proxy = proxy;
             _tlsSettings = tlsSettings ?? MojaveTlsSettings.Default;
@@ -412,7 +415,9 @@ namespace Moljave.Http
                 {
                     case ProxyScheme.Http:
                     case ProxyScheme.Https:
-                        _transportStream = await EstablishHttpTunnelAsync(activeStream, cancellationToken).ConfigureAwait(false);
+                        _transportStream = _targetUsesTls
+                            ? await EstablishHttpTunnelAsync(activeStream, cancellationToken).ConfigureAwait(false)
+                            : activeStream;
                         break;
                     case ProxyScheme.Socks4:
                     case ProxyScheme.Socks4a:

--- a/TlsConnectionPool.cs
+++ b/TlsConnectionPool.cs
@@ -71,6 +71,7 @@ namespace Moljave.Http
                 var client = new TlsClient(
                     host,
                     port,
+                    useTls,
                     fingerprint,
                     proxyDescriptor,
                     tlsSettings,


### PR DESCRIPTION
## Summary
- add cookie manager helpers for updating and pruning cookies without races and preserve metadata cloning
- switch JA3 handling to lightweight presets with new options defaults and documentation examples
- harden HTTP/1.1 proxy flows to send absolute URIs when required and reuse TLS clients safely, including new Examples.md

## Testing
- not run (no automated tests provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb7446aa083328c200d593204c528)